### PR TITLE
Add generated headers from DWARF info

### DIFF
--- a/dwarf/libatcmd.h
+++ b/dwarf/libatcmd.h
@@ -1,0 +1,338 @@
+/* ======== components/stage/atcmd/at_bl602/at_server.c ======== */
+
+struct _at_evt {
+    int evt_id;
+    uint8_t ctx_buf[20];
+    uint32_t ctx_size;
+}; // :34:8
+
+static at_sever_t g_at_server; // :40:19
+
+static int at_serial_read(unsigned char *buf, int size); // :65:12
+static int at_serial_write(unsigned char *buf, int len); // :73:12
+int at_serial_cfg_set(uint32_t baud, uint8_t data_bit, uint8_t stop_bit, uint8_t parity, uint8_t hwfc); // :123:5
+int at_serial_open(void); // :205:5
+int at_serial_close(void); // :210:5
+int at_serial_lock(void); // :217:5
+int at_serial_unlock(void); // :225:5
+int at_data_output(char *buf, int size); // :233:5
+int at_key_value_set(char *key, void *p_value); // :250:5
+int at_key_value_get(char *key, void *p_value); // :287:5
+s32 at_dump_noend(char *format); // :329:5
+void at_async_event(void *param); // :360:6
+void at_cmd_init(void); // :401:6
+static void at_cmd_exec(void *param); // :418:13
+int at_server_init(void); // :425:5
+int at_server_notify(at_evt_t event); // :501:5
+int at_server_notify_with_ctx(at_evt_t event, void *p_ctx, uint32_t ctx_size); // :506:5
+void at_uart_reinit(at_serial_para_t *at_para); // :520:6
+
+/* ======== components/stage/atcmd/at_bl602/bl_socket.c ======== */
+
+static struct server_arg g_server_arg; // :44:26
+static server_ctrl_t g_server_ctrl; // :45:22
+static network_t networks; // :46:18
+static u32 g_server_enable; // :47:12
+SemaphoreHandle_t g_server_sem; // :50:19
+SemaphoreHandle_t g_network_sem; // :51:19
+static int32_t cipsend_totlen; // :54:16
+
+AT_ERROR_CODE bl_cipstatus(at_callback_para_t *para, at_callback_rsp_t *rsp); // :105:15
+static err_t tcp_receive_callback(void *arg, struct altcp_pcb *conn, struct pbuf *p, err_t err); // :126:14
+static err_t tcp_sent_callback(void *arg, struct altcp_pcb *conn, u16_t len); // :168:14
+static void tcp_err_callback(void *arg, err_t err); // :196:13
+static err_t tcp_connected_callback(void *arg, struct altcp_pcb *conn, err_t err); // :213:14
+static void udp_receive_callback(void *arg, struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t *addr, u16_t port); // :255:13
+static int get_romfs_file_content(const char *path, romfs_filebuf_t *buf); // :285:12
+AT_ERROR_CODE bl_cipstart(at_callback_para_t *para, at_callback_rsp_t *rsp); // :296:15
+AT_ERROR_CODE bl_cipsendbuf(at_callback_para_t *para, at_callback_rsp_t *rsp); // :512:15
+AT_ERROR_CODE bl_cipclose(at_callback_para_t *para, at_callback_rsp_t *rsp); // :518:15
+static err_t tcp_accept_callback(void *arg, struct altcp_pcb *new_conn, err_t err); // :538:14
+AT_ERROR_CODE bl_tcpserver(at_callback_para_t *para, at_callback_rsp_t *rsp); // :579:15
+
+struct send_data_ctx {
+    int linkId;
+    uint8_t *buf;
+}; // :665:8
+
+static void tcp_send_data(void *arg); // :672:13
+static void udp_send_data(void *arg); // :693:13
+AT_ERROR_CODE bl_cipsend(at_callback_para_t *para, at_callback_rsp_t *rsp); // :728:15
+AT_ERROR_CODE bl_cipsslcconf_path(at_callback_para_t *para, at_callback_rsp_t *unused); // :774:15
+AT_ERROR_CODE bl_cipsslcsni(at_callback_para_t *para, at_callback_rsp_t *rsp); // :849:15
+AT_ERROR_CODE bl_cipsslcalpn(at_callback_para_t *para, at_callback_rsp_t *unused); // :893:15
+
+/* ======== components/stage/atcmd/at_bl602/bl_socket.h ======== */
+
+struct server_arg {
+    s16 port;
+    s32 protocol;
+}; // :25:8
+
+typedef struct {
+    u32 flag;
+    s16 port;
+    s32 protocol;
+    u32 auth_mode;
+    const char *cert;
+    const char *key;
+    const char *ca;
+    const char **alpn;
+    union {
+        struct udp_pcb *udp;
+        struct altcp_pcb *tcp;
+        struct {
+            struct altcp_pcb *pcb;
+            struct altcp_tls_config *config;
+        } tls;
+    } pcb;
+} server_ctrl_t; // :48:3
+
+enum socket_state {
+    SOCK_IDLE_CLOSE = 0,
+    SOCK_SERVER_LISTENING = 1,
+    SOCK_CLIENT_CONNECTING = 2,
+    SOCK_CLIENT_CONNECTED = 3,
+}; // :50:6
+
+enum socket_type {
+    SOCK_TYPE_TCP = 1,
+    SOCK_TYPE_UDP = 2,
+    SOCK_TYPE_TLS = 3,
+}; // :57:6
+
+enum auth_mode {
+    NO_AUTH = 0,
+    SERVER_AUTH_CERT_KEY = 1,
+    CLIENT_AUTH_CA = 2,
+    BOTH_AUTH = 3,
+}; // :63:6
+
+typedef struct {
+    char ip[16];
+    u32 port;
+    enum socket_type protocol;
+    enum auth_mode auth_mode;
+    const char *sni;
+    const char *ca;
+    const char *cert;
+    const char *key;
+    const char **alpn;
+    union {
+        struct udp_pcb *udp;
+        struct altcp_pcb *tcp;
+        struct {
+            struct altcp_pcb *pcb;
+            struct altcp_tls_config *config;
+        } tls;
+    } pcb;
+    enum socket_state status;
+} connect_t; // :87:3
+
+typedef struct {
+    s32 count;
+    connect_t connect[5];
+} network_t; // :92:3
+
+/* ======== components/stage/atcmd/at_bl602/functions.c ======== */
+
+typedef struct {
+    s32 cmd;
+    AT_ERROR_CODE (*handler)(at_callback_para_t *, at_callback_rsp_t *);
+} callback_handler_t; // :68:3
+
+static wifi_interface_t g_wifi_interface; // :81:25
+int is_disp_ipd; // :84:5
+static const callback_handler_t callback_tbl[27]; // :129:33
+
+u32 at_get_errorcode(void); // :289:5
+int at_cmd_impl_init(void); // :337:5
+AT_ERROR_CODE callback(AT_CALLBACK_CMD cmd, at_callback_para_t *para, at_callback_rsp_t *rsp); // :348:15
+static AT_ERROR_CODE reset(at_callback_para_t *para, at_callback_rsp_t *rsp); // :370:22
+static AT_ERROR_CODE scan(at_callback_para_t *para, at_callback_rsp_t *rsp); // :795:22
+static AT_ERROR_CODE version(at_callback_para_t *para, at_callback_rsp_t *rsp); // :870:22
+static AT_ERROR_CODE restory(at_callback_para_t *para, at_callback_rsp_t *rsp); // :880:22
+static AT_ERROR_CODE uart_get(at_callback_para_t *para, at_callback_rsp_t *rsp); // :912:22
+static AT_ERROR_CODE uart_set(at_callback_para_t *para, at_callback_rsp_t *rsp); // :939:22
+static AT_ERROR_CODE deep_sleep(at_callback_para_t *para, at_callback_rsp_t *rsp); // :962:22
+
+enum wlan_mode {
+    WIFI_DISABLE = 0,
+    WIFI_STATION_MODE = 1,
+    WIFI_SOFTAP_MODE = 2,
+    WIFI_AP_STA_MODE = 3,
+}; // :1022:6
+
+static char g_soft_ap_ssid[65]; // :1029:13
+
+static AT_ERROR_CODE __wifimode_set(int mode); // :1031:22
+static AT_ERROR_CODE cwmode_cur(at_callback_para_t *para, at_callback_rsp_t *rsp); // :1056:22
+static AT_ERROR_CODE cwmode_cur_get(at_callback_para_t *para, at_callback_rsp_t *rsp); // :1073:22
+
+static char cur_ssid[32]; // :1079:13
+static char cur_psk[65]; // :1080:13
+
+static AT_ERROR_CODE cwjap_cur(at_callback_para_t *para, at_callback_rsp_t *rsp); // :1081:22
+static AT_ERROR_CODE cwjap_info(at_callback_para_t *para, at_callback_rsp_t *rsp); // :1125:22
+static AT_ERROR_CODE cwqap(at_callback_para_t *para, at_callback_rsp_t *rsp); // :1170:22
+static AT_ERROR_CODE ap_sta_get(at_callback_para_t *para, at_callback_rsp_t *rsp); // :1242:22
+static AT_ERROR_CODE set_apcfg(at_callback_para_t *para, at_callback_rsp_t *rsp); // :1285:22
+static AT_ERROR_CODE cipsta_ip_get(at_callback_para_t *para, at_callback_rsp_t *rsp); // :1315:22
+static AT_ERROR_CODE cipsta_ip(at_callback_para_t *para, at_callback_rsp_t *rsp); // :1332:22
+
+static SemaphoreHandle_t g_http_xSemaphore; // :1450:26
+
+static void cb_httpc_result(void *arg, httpc_result_t httpc_result, u32_t rx_content_len, u32_t srv_res, err_t err); // :1451:13
+static err_t cb_httpc_headers_done_fn(httpc_state_t *connection, void *arg, struct pbuf *hdr, u16_t hdr_len, u32_t content_len); // :1459:14
+static err_t cb_altcp_recv_fn(void *arg, struct altcp_pcb *conn, struct pbuf *p, err_t err); // :1472:14
+static AT_ERROR_CODE http_url_req(at_callback_para_t *para, at_callback_rsp_t *rsp); // :1498:22
+static AT_ERROR_CODE ble_sync(at_callback_para_t *para, at_callback_rsp_t *rsp); // :1565:22
+
+/* ======== components/stage/atcmd/src/at_command.c ======== */
+
+at_callback_t at_callback; // :37:15
+char *c_atCmdRspBuf[1028]; // :39:7
+static const at_command_handler_t *g_at_cmd_handler_usr; // :40:36
+static uint32_t g_at_cmd_usr_cnt; // :41:17
+static cmd_cache_t cache; // :43:20
+cmd_send_cache_t send_cache; // :44:18
+static int reconnect_enable; // :45:12
+static const at_command_handler_t at_command_table[28]; // :69:35
+
+int get_reconnect_enable_status(void); // :1542:5
+AT_ERROR_CODE at_get_ssid_psk(char **ppara, char *ssid, char *pwd); // :1544:15
+static AT_ERROR_CODE join_ap_handler(at_para_t *at_para); // :1583:22
+static AT_ERROR_CODE disconnect_handler(at_para_t *at_para); // :1624:22
+static AT_ERROR_CODE setautoconnect_handler(at_para_t *at_para); // :1639:22
+static AT_ERROR_CODE set_ip_handler(at_para_t *at_para); // :1688:22
+
+/* ======== components/stage/atcmd/src/at_common.c ======== */
+
+typedef struct {
+    AT_ERROR_CODE aec;
+    const char *info;
+} err_info_t; // :40:3
+
+static const err_info_t err_info[24]; // :42:25
+
+void at_response(AT_ERROR_CODE aec); // :69:6
+s32 at_event(s32 idx); // :98:5
+s32 at_serial(at_serial_para_t *ppara); // :112:5
+AT_ERROR_CODE at_act(void); // :119:15
+AT_ERROR_CODE at_reset(void); // :131:15
+AT_ERROR_CODE at_mode(AT_MODE mode); // :139:15
+
+/* ======== components/stage/atcmd/src/at_config.c ======== */
+
+at_config_t at_cfg; // :63:13
+static const at_var_descriptor_t at_cfg_table[22]; // :65:34
+
+AT_ERROR_CODE at_getcfg(char *key); // :126:15
+AT_ERROR_CODE at_typecfg(char *key); // :148:15
+AT_ERROR_CODE at_setcfg(char *key, at_value_t *value); // :165:15
+AT_ERROR_CODE at_ssidtxt(char *ssid); // :194:15
+AT_ERROR_CODE at_config(void); // :211:15
+AT_ERROR_CODE at_factory(void); // :225:15
+AT_ERROR_CODE at_save(void); // :238:15
+static s32 localecho1_verify(at_value_t *value); // :261:12
+static s32 console1_speed_verify(at_value_t *value); // :271:12
+static s32 console1_hwfc_verify(at_value_t *value); // :287:12
+static s32 wifi_ssid_len_verify(at_value_t *value); // :391:12
+static s32 wifi_mode_verify(at_value_t *value); // :401:12
+static s32 ip_use_dhcp_verify(at_value_t *value); // :451:12
+
+/* ======== components/stage/atcmd/src/at_extend.c ======== */
+
+AT_ERROR_CODE at_version(char *version); // :36:15
+AT_ERROR_CODE at_restore(char *address); // :50:15
+AT_ERROR_CODE at_uart_config_get(void); // :66:15
+AT_ERROR_CODE at_uart_config(int uartId, int uartBaud, int dataBit, int parity, int stopBit, int hwfc); // :92:15
+AT_ERROR_CODE at_deep_sleep_mode(uint32_t sleep_time, int weakup_pin); // :129:15
+AT_ERROR_CODE at_wifi_mode(int wifiMode); // :162:15
+AT_ERROR_CODE at_wifi_mode_get(void); // :181:15
+AT_ERROR_CODE at_get_apinfo(void); // :232:15
+AT_ERROR_CODE at_join_ap(char *ssid, char *pwd); // :237:15
+AT_ERROR_CODE at_scan_attr(char *at_para); // :267:15
+AT_ERROR_CODE at_disconnect(char *at_para); // :274:15
+AT_ERROR_CODE at_set_dhcp(unsigned char *at_para); // :287:15
+AT_ERROR_CODE at_set_mac(unsigned char *at_para); // :300:15
+AT_ERROR_CODE at_set_hostname(char *hostname); // :315:15
+AT_ERROR_CODE at_network_status(char *param, at_callback_rsp_t *rsp); // :328:22
+AT_ERROR_CODE at_domain_query(char *dnsAdress); // :340:22
+AT_ERROR_CODE at_send_tcp_buffer(char *tcpBuffer); // :355:22
+AT_ERROR_CODE at_set_ap(char *ssid, char *psk, char chl, int max_conn); // :368:22
+AT_ERROR_CODE at_ap_sta_get(void); // :387:22
+AT_ERROR_CODE at_mux_network(int mux); // :400:22
+AT_ERROR_CODE at_set_trans_mode(int mode); // :415:22
+AT_ERROR_CODE at_http_request(char *url, uint8_t type, uint8_t content_type, uint8_t *data, at_callback_rsp_t *req_rsp); // :428:22
+AT_ERROR_CODE at_set_dns(char *dnsAdress); // :447:22
+AT_ERROR_CODE at_io_cfg(int ID, int mode, int pull); // :461:22
+AT_ERROR_CODE at_get_io_cfg(void); // :478:15
+AT_ERROR_CODE at_set_iodir_cfg(int ID, int mode, int driving, int pull); // :487:22
+AT_ERROR_CODE at_write_io_data(int ID, int data); // :503:22
+AT_ERROR_CODE at_read_io_data(int ID, int data); // :519:22
+
+/* ======== components/stage/atcmd/src/at_gpio.c ======== */
+
+AT_ERROR_CODE at_gpioc(s32 num, char *direction, char *interrupt); // :34:15
+AT_ERROR_CODE at_gpior(s32 num); // :40:15
+AT_ERROR_CODE at_gpiow(s32 num, s32 value); // :46:15
+
+/* ======== components/stage/atcmd/src/at_parameter.c ======== */
+
+s32 at_get_value(char *strbuf, s32 pt, void *pvar, s32 vsize); // :36:5
+s32 at_set_value(s32 pt, void *pvar, s32 vsize, at_value_t *value); // :80:5
+int at_atoi(char *str); // :123:5
+static int hex_to_num(char ch); // :138:12
+static u32 get_text_para(char **ppara, void *pvar, u32 opt); // :171:12
+static u32 get_tdata_para(char **ppara, void *pvar, u32 opt); // :241:12
+static u32 get_hex_para(char **ppara, void *pvar, u32 opt); // :315:12
+static u32 get_di_para(char **ppara, void *pvar, u32 opt); // :428:12
+static u32 get_hi_para(char **ppara, void *pvar, u32 opt); // :515:12
+static u32 get_ip_para(char **ppara, void *pvar, u32 opt); // :598:12
+AT_ERROR_CODE at_get_parameters(char **ppara, at_para_descriptor_t *list, s32 lsize, s32 *pcnt); // :732:15
+AT_ERROR_CODE at_get_newline(char *para, s32 size); // :835:15
+
+/* ======== components/stage/atcmd/src/at_queue.c ======== */
+
+static at_queue_callback_t at_queue_callback; // :34:28
+static at_queue_t at_queue; // :35:19
+
+s32 at_queue_init(void *buf, s32 size, at_queue_callback_t cb); // :37:5
+AT_QUEUE_ERROR_CODE at_queue_get(u8 *element); // :55:21
+AT_QUEUE_ERROR_CODE at_queue_peek(u8 *element); // :95:21
+
+/* ======== components/stage/atcmd/src/at_socket.c ======== */
+
+AT_ERROR_CODE create_tcp_udp_handler(at_para_t *at_para); // :39:15
+AT_ERROR_CODE close_network_handler(at_para_t *at_para); // :120:15
+AT_ERROR_CODE send_data_handler(at_para_t *at_para); // :157:15
+AT_ERROR_CODE ap_server_handler(at_para_t *at_para); // :222:15
+AT_ERROR_CODE client_ssl_config_path(at_para_t *at_para); // :278:15
+AT_ERROR_CODE client_ssl_set_sni(at_para_t *at_para); // :378:15
+AT_ERROR_CODE client_ssl_set_alpn(at_para_t *at_para); // :415:15
+
+/* ======== components/stage/atcmd/src/at_status.c ======== */
+
+static at_status_t at_sts; // :36:20
+static at_peer_t dummy_peer; // :37:18
+static const at_var_descriptor_t at_sts_table[7]; // :39:34
+static const at_var_descriptor_t at_peer_table[22]; // :70:34
+
+AT_ERROR_CODE at_status(char *sts_var); // :95:15
+AT_ERROR_CODE at_setsts(char *key, at_value_t *value); // :131:15
+AT_ERROR_CODE at_peer(s32 pn, at_peer_t *peer, char *var); // :150:15
+
+/* ======== components/stage/atcmd/src/at_upgrade.c ======== */
+
+AT_ERROR_CODE at_upgrade(char *hostname, char *path, s32 port); // :34:15
+
+/* ======== components/stage/atcmd/src/at_wlan.c ======== */
+
+static at_peer_t peers[5]; // :34:18
+
+AT_ERROR_CODE at_peers(s32 pn, char *pv); // :36:15
+AT_ERROR_CODE at_ping(char *hostname); // :60:15
+AT_ERROR_CODE at_wifi(s32 value); // :73:15
+AT_ERROR_CODE at_reassociate(void); // :87:15
+AT_ERROR_CODE at_scan(char *mode, char *repeat); // :100:15

--- a/dwarf/libbl602_wifi.h
+++ b/dwarf/libbl602_wifi.h
@@ -1,0 +1,5107 @@
+/* ======== components/bl602/bl602_wifi/ip/cfg/cfg_api.c ======== */
+
+const char *cfg_api_element_dump(void *val, enum CFG_ELEMENT_TYPE type, char *strs); // :6:13
+int cfg_api_element_general_set(struct cfg_element_entry *entry, void *arg1, void *arg2); // :106:5
+int cfg_api_element_general_get(struct cfg_element_entry *entry, void *arg1, void *arg2); // :157:5
+int cfg_api_element_set(uint32_t task, uint32_t element, uint32_t type, void *arg1, void *arg2); // :162:5
+
+/* ======== components/bl602/bl602_wifi/ip/cfg/cfg_api.h ======== */
+
+struct cfg_element_entry {
+    uint32_t task;
+    uint16_t element;
+    uint16_t type;
+    char *name;
+    void *val;
+    int (*set)(struct cfg_element_entry *, void *, void *);
+    int (*get)(struct cfg_element_entry *, void *, void *);
+    int (*notify)(struct cfg_element_entry *, void *, void *, enum CFG_ELEMENT_TYPE_OPS);
+}; // :7:8
+
+/* ======== components/bl602/bl602_wifi/ip/cfg/cfg_task.c ======== */
+
+void dump_cfg_entries(void); // :21:6
+static int cfg_start_req_handler(const ke_msg_id_t msgid, struct cfg_start_req *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :42:12
+
+const struct ke_msg_handler cfg_default_state[1]; // :87:29
+const struct ke_state_handler cfg_default_handler; // :93:31
+ke_state_t cfg_state[1]; // :97:12
+
+/* ======== components/bl602/bl602_wifi/ip/cfg/cfg_task.h ======== */
+
+enum cfg_state_tag {
+    CFG_IDLE = 0,
+    CFG_STATE_MAX = 1,
+}; // :11:6
+
+enum cfg_msg_tag {
+    CFG_START_REQ = 12288,
+    CFG_START_CFM = 12289,
+}; // :20:6
+
+struct {
+    uint32_t task;
+    uint32_t element;
+    uint32_t length;
+    uint32_t buf[0];
+} cfg_start_req_u_tlv_t; // :37:3
+
+struct cfg_start_req {
+    uint32_t ops;
+    union {
+        struct {
+            uint32_t task;
+            uint32_t element;
+        } get[];
+        struct {
+            uint32_t task;
+            uint32_t element;
+        } reset[];
+        struct {
+            uint32_t task;
+            uint32_t element;
+            uint32_t type;
+            uint32_t length;
+            uint32_t buf[0];
+        } set[];
+    } u;
+}; // :39:8
+
+struct cfg_start_cfm {
+    uint8_t status;
+}; // :76:8
+
+const struct ke_state_handler cfg_default_handler; // :82:38
+ke_state_t cfg_state[1]; // :83:19
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/bl/bl.c ======== */
+
+struct bl_env_tag bl_env; // :47:19
+static struct notifier_block *fw_nap_chain_ptr; // :50:31
+struct notifier_block fw_nap_chain; // :51:23
+
+void bl_init(void); // :67:6
+void bl_reset_evt(int dummy); // :130:6
+int bl_sleep(void); // :178:5
+void bl_wakeup(void); // :236:6
+uint32_t bl_nap_calculate(void); // :266:10
+int bl_nap_call(uint32_t time); // :291:5
+int bl_nap_hook_register(struct notifier_block *nb); // :296:5
+int bl_nap_hook_register_fromCritical(struct notifier_block *nb); // :302:5
+int bl_nap_hook_unregister(struct notifier_block *nb); // :308:5
+int bl_nap_hook_unregister_fromCritical(struct notifier_block *nb); // :314:5
+int bl_nap_hook_call(int event, void *env); // :320:5
+int bl_nap_hook_call_fromCritical(int event, void *env); // :326:5
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/bl/bl.h ======== */
+
+struct bl_env_tag {
+    uint8_t prev_hw_state;
+    int hw_in_doze;
+}; // :33:8
+
+struct bl_env_tag bl_env; // :48:26
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/chan/chan.c ======== */
+
+struct chan_env_tag chan_env; // :95:21
+struct chan_ctxt_tag chan_ctxt_pool[5]; // :98:22
+
+static void chan_ctxt_op_evt(void *env); // :916:13
+static void chan_pre_switch_channel(void); // :1077:13
+static void chan_tx_cfm(void *dummy, uint32_t status); // :1162:13
+static void chan_goto_idle_cb(void); // :1334:13
+static void chan_tbtt_insert(struct chan_tbtt_tag *p_tbtt_entry); // :1618:13
+static void chan_tbtt_switch_evt(void *env); // :1754:13
+static void chan_tbtt_schedule(struct chan_tbtt_tag *p_tbtt_entry); // :1836:13
+static void chan_switch_start(struct chan_ctxt_tag *p_chan_entry); // :2055:13
+void chan_init(void); // :2163:6
+void chan_scan_req(uint8_t band, uint16_t freq, int8_t pwr, uint32_t duration_us, uint8_t vif_index); // :2201:6
+uint8_t chan_roc_req(const struct mm_remain_on_channel_req *req, ke_task_id_t taskid); // :2232:9
+uint8_t chan_ctxt_add(const struct mm_chan_ctxt_add_req *p_add_req, uint8_t *idx); // :2385:9
+void chan_ctxt_del(uint8_t chan_idx); // :2433:6
+void chan_ctxt_link(uint8_t vif_idx, uint8_t chan_idx); // :2452:6
+void chan_ctxt_unlink(uint8_t vif_idx); // :2523:6
+void chan_ctxt_update(const struct mm_chan_ctxt_update_req *p_upd_req); // :2650:6
+void chan_tbtt_switch_update(struct vif_info_tag *p_vif_entry, uint32_t tbtt_time); // :2716:6
+void chan_bcn_to_evt(struct vif_info_tag *p_vif_entry); // :2764:6
+void chan_bcn_detect_start(struct vif_info_tag *p_vif_entry); // :2835:6
+bool chan_is_on_channel(struct vif_info_tag *p_vif_entry); // :2955:5
+bool chan_is_tx_allowed(struct vif_info_tag *p_vif_entry); // :2974:5
+bool chan_is_on_operational_channel(struct vif_info_tag *p_vif_entry); // :2986:5
+void chan_update_tx_power(struct chan_ctxt_tag *p_chan_entry); // :3001:6
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/chan/chan.h ======== */
+
+enum chan_ctxt_status {
+    CHAN_NOT_SCHEDULED = 0,
+    CHAN_NOT_PROG = 1,
+    CHAN_GOTO_IDLE = 2,
+    CHAN_WAIT_NOA_CFM = 3,
+    CHAN_WAITING_END = 4,
+    CHAN_PRESENT = 5,
+    CHAN_SENDING_NOA = 6,
+    CHAN_CTXT_STATUS_MAX = 7,
+}; // :88:6
+
+enum chan_tbtt_status {
+    CHAN_TBTT_NOT_PROG = 0,
+    CHAN_TBTT_PROG = 1,
+    CHAN_TBTT_PRESENCE = 2,
+    CHAN_TBTT_STATUS_MAX = 3,
+}; // :109:6
+
+enum chan_env_status_bit {
+    CHAN_ENV_ROC_WAIT_BIT = 0,
+    CHAN_ENV_SCAN_WAIT_BIT = 1,
+    CHAN_ENV_ROC_BIT = 2,
+    CHAN_ENV_SCAN_BIT = 3,
+    CHAN_ENV_DELAY_PROG_BIT = 4,
+    CHAN_ENV_TIMEOUT_BIT = 5,
+    CHAN_ENV_BCN_DETECT_BIT = 6,
+    CHAN_ENV_BIT_MAX = 7,
+}; // :122:6
+
+struct chan_tbtt_tag {
+    struct co_list_hdr list_hdr;
+    uint32_t time;
+    uint8_t vif_index;
+    uint8_t priority;
+    uint8_t status;
+}; // :148:8
+
+struct chan_ctxt_tag {
+    struct co_list_hdr list_hdr;
+    struct mm_chan_ctxt_add_req channel;
+    ke_task_id_t taskid;
+    uint16_t nb_slots;
+    uint16_t nb_rem_slots;
+    uint16_t nb_res_slots;
+    uint8_t status;
+    uint8_t idx;
+    uint8_t nb_linked_vif;
+    uint8_t vif_index;
+}; // :165:8
+
+struct chan_env_tag {
+    struct co_list list_free_ctxt;
+    struct co_list list_sched_ctxt;
+    struct co_list list_tbtt;
+    struct co_list list_tbtt_delay;
+    struct chan_ctxt_tag *current_channel;
+    struct chan_ctxt_tag *chan_switch;
+    struct mm_timer_tag tmr_tbtt_switch;
+    struct mm_timer_tag tmr_cde;
+    struct mm_timer_tag tmr_ctxt_op;
+    struct mm_timer_tag tmr_conn_less;
+    uint32_t cde_dur_us;
+    uint32_t cde_time;
+    uint8_t status;
+    uint8_t cfm_cnt;
+    uint8_t nb_sched_ctxt;
+    uint8_t pm;
+}; // :211:8
+
+struct chan_env_tag chan_env; // :268:28
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/hal/hal_desc.c ======== */
+
+struct rx_dmadesc rx_dma_hdrdesc[]; // :40:19
+struct rx_payloaddesc rx_payload_desc[]; // :41:23
+uint32_t rx_payload_desc_buffer[13]; // :42:10
+struct dma_desc bcn_dwnld_desc; // :47:17
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/hal/hal_desc.h ======== */
+
+struct tx_policy_tbl {
+    uint32_t upatterntx;
+    uint32_t phycntrlinfo1;
+    uint32_t phycntrlinfo2;
+    uint32_t maccntrlinfo1;
+    uint32_t maccntrlinfo2;
+    uint32_t ratecntrlinfo[4];
+    uint32_t powercntrlinfo[4];
+}; // :669:8
+
+struct tx_compressed_policy_tbl {
+    uint32_t upatterntx;
+    uint32_t sec_user_control;
+}; // :689:8
+
+struct tx_hd {
+    uint32_t upatterntx;
+    uint32_t nextfrmexseq_ptr;
+    uint32_t nextmpdudesc_ptr;
+    union {
+        uint32_t first_pbd_ptr;
+        uint32_t sec_user1_ptr;
+    } ;
+    union {
+        uint32_t datastartptr;
+        uint32_t sec_user2_ptr;
+    } ;
+    union {
+        uint32_t dataendptr;
+        uint32_t sec_user3_ptr;
+    } ;
+    uint32_t frmlen;
+    uint32_t frmlifetime;
+    uint32_t phyctrlinfo;
+    uint32_t policyentryaddr;
+    uint32_t optlen[3];
+    uint32_t macctrlinfo1;
+    uint32_t macctrlinfo2;
+    uint32_t statinfo;
+    uint32_t mediumtimeused;
+}; // :698:8
+
+struct tx_pbd {
+    uint32_t upatterntx;
+    uint32_t next;
+    uint32_t datastartptr;
+    uint32_t dataendptr;
+    uint32_t bufctrlinfo;
+}; // :748:8
+
+struct rx_hd {
+    uint32_t upatternrx;
+    uint32_t next;
+    uint32_t first_pbd_ptr;
+    struct rx_swdesc *swdesc;
+    uint32_t datastartptr;
+    uint32_t dataendptr;
+    uint32_t headerctrlinfo;
+    uint16_t frmlen;
+    uint16_t ampdu_stat_info;
+    uint32_t tsflo;
+    uint32_t tsfhi;
+    uint32_t recvec1a;
+    uint32_t recvec1b;
+    uint32_t recvec1c;
+    uint32_t recvec1d;
+    uint32_t recvec2a;
+    uint32_t recvec2b;
+    uint32_t statinfo;
+}; // :774:8
+
+struct rx_pbd {
+    uint32_t upattern;
+    uint32_t next;
+    uint32_t datastartptr;
+    uint32_t dataendptr;
+    uint16_t bufstatinfo;
+    uint16_t reserved;
+}; // :816:8
+
+struct rx_dmadesc {
+    struct rx_hd hd;
+    struct phy_channel_info phy_info;
+    uint32_t flags;
+    uint32_t pattern;
+    uint32_t payl_offset;
+    uint32_t reserved_pad[2];
+    uint32_t use_in_tcpip;
+}; // :834:8
+
+struct rx_payloaddesc {
+    struct rx_pbd pbd;
+    uint32_t pd_status;
+    uint32_t *buffer_rx;
+    void *pbuf_holder[6];
+}; // :854:8
+
+struct tx_cfm_tag {
+    uint16_t pn[4];
+    uint16_t sn;
+    uint16_t timestamp;
+    int8_t credits;
+    uint8_t ampdu_size;
+    uint8_t pad[2];
+    uint32_t status;
+}; // :865:8
+
+struct tx_hw_desc {
+    struct tx_cfm_tag *cfm_ptr;
+    struct tx_hd thd;
+}; // :885:8
+
+struct tx_agg_desc {
+    uint8_t reserved;
+}; // :979:8
+
+struct dma_desc bcn_dwnld_desc; // :1048:24
+struct rx_dmadesc rx_dma_hdrdesc[]; // :1052:26
+struct rx_payloaddesc rx_payload_desc[]; // :1054:30
+uint32_t rx_payload_desc_buffer[13]; // :1055:17
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/hal/hal_dma.c ======== */
+
+const uint8_t dma2chan[2]; // :39:15
+const uint8_t dma2lli[2]; // :46:15
+struct hal_dma_env_tag hal_dma_env; // :61:24
+
+void hal_dma_init(void); // :90:6
+void hal_dma_push(struct hal_dma_desc_tag *desc, int type); // :117:6
+void hal_dma_evt(int dma_queue); // :159:6
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/hal/hal_dma.h ======== */
+
+typedef void (*cb_dma_func_ptr)(void *, int); // :78:16
+
+struct hal_dma_desc_tag {
+    struct co_list_hdr hdr;
+    struct dma_desc *dma_desc;
+    cb_dma_func_ptr cb;
+    void *env;
+}; // :81:8
+
+struct hal_dma_env_tag {
+    struct co_list prog[2];
+    struct co_list free_gp_dma_descs;
+    uint16_t lli_cnt[2];
+}; // :94:8
+
+struct hal_dma_env_tag hal_dma_env; // :109:31
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/hal/hal_machw.c ======== */
+
+const uint8_t rxv2macrate[]; // :103:15
+
+void hal_machw_idle_req(void); // :220:6
+void hal_machw_stop(void); // :250:6
+void hal_machw_init(void); // :257:6
+void hal_machw_disable_int(void); // :378:6
+void hal_machw_reset(void); // :410:6
+uint8_t hal_machw_search_addr(struct mac_addr *addr); // :453:9
+void hal_machw_monitor_mode(void); // :480:6
+bool hal_machw_sleep_check(void); // :502:5
+void hal_machw_gen_handler(void); // :570:6
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/hal/hal_machw.h ======== */
+
+const uint8_t rxv2macrate[]; // :236:22
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/hal/hal_machw_mib.h ======== */
+
+struct machw_mib_tag {
+    uint32_t dot11_wep_excluded_count;
+    uint32_t dot11_fcs_error_count;
+    uint32_t nx_rx_phy_error_count;
+    uint32_t nx_rd_fifo_overflow_count;
+    uint32_t nx_tx_underun_count;
+    uint32_t reserved_1[7];
+    uint32_t nx_qos_utransmitted_mpdu_count[8];
+    uint32_t nx_qos_gtransmitted_mpdu_count[8];
+    uint32_t dot11_qos_failed_count[8];
+    uint32_t dot11_qos_retry_count[8];
+    uint32_t dot11_qos_rts_success_count[8];
+    uint32_t dot11_qos_rts_failure_count[8];
+    uint32_t nx_qos_ack_failure_count[8];
+    uint32_t nx_qos_ureceived_mpdu_count[8];
+    uint32_t nx_qos_greceived_mpdu_count[8];
+    uint32_t nx_qos_ureceived_other_mpdu[8];
+    uint32_t dot11_qos_retries_received_count[8];
+    uint32_t nx_utransmitted_amsdu_count[8];
+    uint32_t nx_gtransmitted_amsdu_count[8];
+    uint32_t dot11_failed_amsdu_count[8];
+    uint32_t dot11_retry_amsdu_count[8];
+    uint32_t dot11_transmitted_octets_in_amsdu[8];
+    uint32_t dot11_amsdu_ack_failure_count[8];
+    uint32_t nx_ureceived_amsdu_count[8];
+    uint32_t nx_greceived_amsdu_count[8];
+    uint32_t nx_ureceived_other_amsdu[8];
+    uint32_t dot11_received_octets_in_amsdu_count[8];
+    uint32_t reserved_2[24];
+    uint32_t dot11_transmitted_ampdu_count;
+    uint32_t dot11_transmitted_mpdus_in_ampdu_count;
+    uint32_t dot11_transmitted_octets_in_ampdu_count;
+    uint32_t wnlu_ampdu_received_count;
+    uint32_t nx_gampdu_received_count;
+    uint32_t nx_other_ampdu_received_count;
+    uint32_t dot11_mpdu_in_received_ampdu_count;
+    uint32_t dot11_received_octets_in_ampdu_count;
+    uint32_t dot11_ampdu_delimiter_crc_error_count;
+    uint32_t dot11_implicit_bar_failure_count;
+    uint32_t dot11_explicit_bar_failure_count;
+    uint32_t reserved_3[5];
+    uint32_t dot11_20mhz_frame_transmitted_count;
+    uint32_t dot11_40mhz_frame_transmitted_count;
+    uint32_t dot11_20mhz_frame_received_count;
+    uint32_t dot11_40mhz_frame_received_count;
+    uint32_t nx_failed_40mhz_txop;
+    uint32_t nx_successful_txops;
+    uint32_t reserved_4[4];
+    uint32_t dot11_dualcts_success_count;
+    uint32_t dot11_stbc_cts_success_count;
+    uint32_t dot11_stbc_cts_failure_count;
+    uint32_t dot11_non_stbc_cts_success_count;
+    uint32_t dot11_non_stbc_cts_failure_count;
+}; // :35:8
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/hal/hal_mib.c ======== */
+
+volatile struct machw_mib_tag *machw_mib; // :34:32
+
+void hal_mib_dump(void); // :35:6
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/mm/mm.c ======== */
+
+struct mm_env_tag mm_env; // :128:19
+
+void mm_env_max_ampdu_duration_set(void); // :131:6
+void mm_env_init(void); // :145:6
+void mm_init(void); // :166:6
+static void mm_ap_probe_cfm(void *env, uint32_t status); // :352:13
+
+uint32_t beacon_rx_count; // :430:10
+
+bool mm_check_beacon(struct rx_hd *rhd, struct vif_info_tag *vif_entry, struct sta_info_tag *p_sta_entry, uint32_t *tim); // :432:5
+void mm_reset(void); // :494:6
+void mm_active(void); // :511:6
+void mm_sta_tbtt(void *env); // :519:6
+void mm_tbtt_evt(int dummy); // :793:6
+uint8_t mm_sec_machwaddr_wr(uint8_t sta_idx, uint8_t inst_nbr); // :813:9
+void mm_sec_keydump(void); // :854:6
+uint8_t mm_sec_machwkey_wr(const struct mm_key_add_req *param); // :953:9
+void mm_sec_machwkey_del(uint8_t hw_key_idx); // :1095:6
+void mm_sec_machwaddr_del(uint8_t sta_idx); // :1154:6
+void mm_hw_idle_evt(int dummy); // :1179:6
+void mm_hw_info_set(const struct mac_addr *mac_addr); // :1189:6
+void mm_hw_ap_info_set(void); // :1212:6
+void mm_hw_ap_info_reset(void); // :1228:6
+void mm_back_to_host_idle(void); // :1319:6
+void mm_force_idle_req(void); // :1340:6
+static unsigned char ascii_to_hex(char asccode); // :1363:22
+
+uint8_t wep_hw_keyid; // :1401:9
+
+uint8_t mm_sta_add(const struct mm_sta_add_req *param, uint8_t *sta_idx, uint8_t *hw_sta_idx); // :1404:9
+void mm_sta_del(uint8_t sta_idx); // :1512:6
+void mm_cfg_element_keepalive_timestamp_update(void); // :1596:6
+void mm_send_connection_loss_ind(struct vif_info_tag *p_vif_entry); // :1603:6
+
+static long long last_us; // :1617:18
+
+void mm_check_rssi(struct vif_info_tag *vif_entry, int8_t rssi); // :1618:6
+void mm_send_csa_traffic_ind(uint8_t vif_index, bool enable); // :1684:6
+uint16_t mm_get_rsn_wpa_ie(uint8_t sta_id, uint8_t *wpa_ie); // :1695:10
+static int element_notify_status_enabled(struct cfg_element_entry *entry, void *arg1, void *arg2, enum CFG_ELEMENT_TYPE_OPS ops); // :1705:12
+static int element_notify_time_last_received_set(struct cfg_element_entry *entry, void *arg1, void *arg2, enum CFG_ELEMENT_TYPE_OPS ops); // :1712:12
+static int element_notify_keepalive_received(struct cfg_element_entry *entry, void *arg1, void *arg2, enum CFG_ELEMENT_TYPE_OPS ops); // :1719:12
+
+static const struct cfg_element_entry cfg_entrys_mm[3]; // :1726:39
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/mm/mm.h ======== */
+
+enum mm_features {
+    MM_FEAT_BCN_BIT = 0,
+    MM_FEAT_AUTOBCN_BIT = 1,
+    MM_FEAT_HWSCAN_BIT = 2,
+    MM_FEAT_CMON_BIT = 3,
+    MM_FEAT_MROLE_BIT = 4,
+    MM_FEAT_RADAR_BIT = 5,
+    MM_FEAT_PS_BIT = 6,
+    MM_FEAT_UAPSD_BIT = 7,
+    MM_FEAT_DPSM_BIT = 8,
+    MM_FEAT_AMPDU_BIT = 9,
+    MM_FEAT_AMSDU_BIT = 10,
+    MM_FEAT_CHNL_CTXT_BIT = 11,
+    MM_FEAT_REORD_BIT = 12,
+    MM_FEAT_P2P_BIT = 13,
+    MM_FEAT_P2P_GO_BIT = 14,
+    MM_FEAT_UMAC_BIT = 15,
+    MM_FEAT_VHT_BIT = 16,
+    MM_FEAT_BFMEE_BIT = 17,
+    MM_FEAT_BFMER_BIT = 18,
+    MM_FEAT_WAPI_BIT = 19,
+    MM_FEAT_MFP_BIT = 20,
+    MM_FEAT_MU_MIMO_RX_BIT = 21,
+    MM_FEAT_MU_MIMO_TX_BIT = 22,
+    MM_FEAT_MESH_BIT = 23,
+    MM_FEAT_TDLS_BIT = 24,
+}; // :199:6
+
+struct mm_env_tag {
+    uint32_t rx_filter_umac;
+    uint32_t rx_filter_lmac_enable;
+    uint16_t ampdu_max_dur[5];
+    uint8_t prev_mm_state;
+    uint8_t prev_hw_state;
+    uint32_t basic_rates[2];
+    uint32_t uapsd_timeout;
+    uint16_t lp_clk_accuracy;
+    uint8_t host_idle;
+    bool keep_alive_status_enabled;
+    uint32_t keep_alive_packet_counter;
+    uint32_t keep_alive_time_last_received;
+}; // :258:8
+
+struct mm_env_tag mm_env; // :297:26
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/mm/mm_bcn.c ======== */
+
+struct mm_bcn_env_tag mm_bcn_env; // :62:23
+
+static void mm_tim_update_proceed(const struct mm_tim_update_req *param); // :74:13
+static void mm_bcn_updated(void *env, int dma_queue); // :495:13
+static void mm_bcn_update(const struct mm_bcn_change_req *param); // :533:13
+static void mm_bcn_transmitted(void *env, uint32_t status); // :572:13
+void mm_bcn_init(void); // :724:6
+void mm_bcn_init_vif(struct vif_info_tag *vif_entry); // :750:6
+void mm_bcn_change(const struct mm_bcn_change_req *param); // :787:6
+void mm_tim_update(const struct mm_tim_update_req *param); // :804:6
+void mm_bcn_transmit(void); // :819:6
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/mm/mm_bcn.h ======== */
+
+struct mm_bcn_env_tag {
+    const struct mm_bcn_change_req *param;
+    int tx_cfm;
+    bool tx_pending;
+    bool update_ongoing;
+    bool update_pending;
+    struct hal_dma_desc_tag dma;
+    struct co_list tim_list;
+}; // :56:8
+
+struct mm_bcn_env_tag mm_bcn_env; // :85:30
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/mm/mm_task.c ======== */
+
+int bl60x_edca_get(int ac, uint8_t *aifs, uint8_t *cwmin, uint8_t *cwmax, uint16_t *txop); // :63:5
+static int mm_version_req_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :121:1
+static int mm_reset_req_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :251:1
+static int mm_start_req_handler(const ke_msg_id_t msgid, const struct mm_start_req *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :303:1
+static int mm_set_power_req_handler(const ke_msg_id_t msgid, const struct mm_set_power_req *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :969:1
+static int mm_set_idle_req_handler(const ke_msg_id_t msgid, const struct mm_set_idle_req *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :1127:1
+static int mm_force_idle_req_handler(const ke_msg_id_t msgid, const struct mm_force_idle_req *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :1206:1
+static int mm_sta_add_req_handler(const ke_msg_id_t msgid, const struct mm_sta_add_req *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :1262:1
+static int mm_sta_del_req_handler(const ke_msg_id_t msgid, const struct mm_sta_del_req *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :1297:1
+static int mm_key_add_req_handler(const ke_msg_id_t msgid, const struct mm_key_add_req *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :1328:1
+static int mm_key_del_req_handler(const ke_msg_id_t msgid, const struct mm_key_del_req *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :1381:1
+static int mm_remain_on_channel_req_handler(const ke_msg_id_t msgid, const struct mm_remain_on_channel_req *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :1792:1
+static int mm_bcn_change_req_handler(const ke_msg_id_t msgid, const struct mm_bcn_change_req *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :1838:1
+static int mm_tim_update_req_handler(const ke_msg_id_t msgid, const struct mm_tim_update_req *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :1865:1
+static int mm_hw_config_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :1903:1
+static int mm_set_ps_mode_req_handler(const ke_msg_id_t msgid, const struct mm_set_ps_mode_req *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :2015:1
+static int mm_set_ps_options_req_handler(const ke_msg_id_t msgid, const struct mm_set_ps_options_req *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :2061:1
+static int mm_cfg_rssi_req_handler(const ke_msg_id_t msgid, const struct mm_cfg_rssi_req *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :2294:12
+static int mm_monitor_enable_req_handler(const ke_msg_id_t msgid, const struct mm_monitor_req *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :2330:1
+static int mm_monitor_channel_req_handler(const ke_msg_id_t msgid, const struct mm_monitor_channel_req *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :2387:1
+
+const struct ke_msg_handler mm_default_state[33]; // :2431:29
+const struct ke_state_handler mm_state_handler[4]; // :2544:31
+const struct ke_state_handler mm_default_handler; // :2553:31
+ke_state_t mm_state[1]; // :2557:12
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/mm/mm_task.h ======== */
+
+enum mm_state_tag {
+    MM_IDLE = 0,
+    MM_ACTIVE = 1,
+    MM_GOING_TO_IDLE = 2,
+    MM_HOST_BYPASSED = 3,
+    MM_STATE_MAX = 4,
+}; // :45:6
+
+enum mm_remain_on_channel_op {
+    MM_ROC_OP_START = 0,
+    MM_ROC_OP_CANCEL = 1,
+    MM_ROC_OP_MAX = 2,
+}; // :60:6
+
+enum mm_msg_tag {
+    MM_RESET_REQ = 0,
+    MM_RESET_CFM = 1,
+    MM_START_REQ = 2,
+    MM_START_CFM = 3,
+    MM_VERSION_REQ = 4,
+    MM_VERSION_CFM = 5,
+    MM_ADD_IF_REQ = 6,
+    MM_ADD_IF_CFM = 7,
+    MM_REMOVE_IF_REQ = 8,
+    MM_REMOVE_IF_CFM = 9,
+    MM_STA_ADD_REQ = 10,
+    MM_STA_ADD_CFM = 11,
+    MM_STA_DEL_REQ = 12,
+    MM_STA_DEL_CFM = 13,
+    MM_SET_FILTER_REQ = 14,
+    MM_SET_FILTER_CFM = 15,
+    MM_SET_CHANNEL_REQ = 16,
+    MM_SET_CHANNEL_CFM = 17,
+    MM_SET_DTIM_REQ = 18,
+    MM_SET_DTIM_CFM = 19,
+    MM_SET_BEACON_INT_REQ = 20,
+    MM_SET_BEACON_INT_CFM = 21,
+    MM_SET_BASIC_RATES_REQ = 22,
+    MM_SET_BASIC_RATES_CFM = 23,
+    MM_SET_BSSID_REQ = 24,
+    MM_SET_BSSID_CFM = 25,
+    MM_SET_EDCA_REQ = 26,
+    MM_SET_EDCA_CFM = 27,
+    MM_SET_MODE_REQ = 28,
+    MM_SET_MODE_CFM = 29,
+    MM_SET_VIF_STATE_REQ = 30,
+    MM_SET_VIF_STATE_CFM = 31,
+    MM_SET_SLOTTIME_REQ = 32,
+    MM_SET_SLOTTIME_CFM = 33,
+    MM_SET_IDLE_REQ = 34,
+    MM_SET_IDLE_CFM = 35,
+    MM_KEY_ADD_REQ = 36,
+    MM_KEY_ADD_CFM = 37,
+    MM_KEY_DEL_REQ = 38,
+    MM_KEY_DEL_CFM = 39,
+    MM_BA_ADD_REQ = 40,
+    MM_BA_ADD_CFM = 41,
+    MM_BA_DEL_REQ = 42,
+    MM_BA_DEL_CFM = 43,
+    MM_PRIMARY_TBTT_IND = 44,
+    MM_SECONDARY_TBTT_IND = 45,
+    MM_SET_POWER_REQ = 46,
+    MM_SET_POWER_CFM = 47,
+    MM_DENOISE_REQ = 48,
+    MM_SET_PS_MODE_REQ = 49,
+    MM_SET_PS_MODE_CFM = 50,
+    MM_CHAN_CTXT_ADD_REQ = 51,
+    MM_CHAN_CTXT_ADD_CFM = 52,
+    MM_CHAN_CTXT_DEL_REQ = 53,
+    MM_CHAN_CTXT_DEL_CFM = 54,
+    MM_CHAN_CTXT_LINK_REQ = 55,
+    MM_CHAN_CTXT_LINK_CFM = 56,
+    MM_CHAN_CTXT_UNLINK_REQ = 57,
+    MM_CHAN_CTXT_UNLINK_CFM = 58,
+    MM_CHAN_CTXT_UPDATE_REQ = 59,
+    MM_CHAN_CTXT_UPDATE_CFM = 60,
+    MM_CHAN_CTXT_SCHED_REQ = 61,
+    MM_CHAN_CTXT_SCHED_CFM = 62,
+    MM_BCN_CHANGE_REQ = 63,
+    MM_BCN_CHANGE_CFM = 64,
+    MM_TIM_UPDATE_REQ = 65,
+    MM_TIM_UPDATE_CFM = 66,
+    MM_CONNECTION_LOSS_IND = 67,
+    MM_CHANNEL_SWITCH_IND = 68,
+    MM_CHANNEL_PRE_SWITCH_IND = 69,
+    MM_REMAIN_ON_CHANNEL_REQ = 70,
+    MM_REMAIN_ON_CHANNEL_CFM = 71,
+    MM_REMAIN_ON_CHANNEL_EXP_IND = 72,
+    MM_PS_CHANGE_IND = 73,
+    MM_TRAFFIC_REQ_IND = 74,
+    MM_SET_PS_OPTIONS_REQ = 75,
+    MM_SET_PS_OPTIONS_CFM = 76,
+    MM_P2P_VIF_PS_CHANGE_IND = 77,
+    MM_CSA_COUNTER_IND = 78,
+    MM_CHANNEL_SURVEY_IND = 79,
+    MM_BFMER_ENABLE_REQ = 80,
+    MM_SET_P2P_NOA_REQ = 81,
+    MM_SET_P2P_OPPPS_REQ = 82,
+    MM_SET_P2P_NOA_CFM = 83,
+    MM_SET_P2P_OPPPS_CFM = 84,
+    MM_P2P_NOA_UPD_IND = 85,
+    MM_CFG_RSSI_REQ = 86,
+    MM_RSSI_STATUS_IND = 87,
+    MM_CSA_FINISH_IND = 88,
+    MM_CSA_TRAFFIC_IND = 89,
+    MM_MU_GROUP_UPDATE_REQ = 90,
+    MM_MU_GROUP_UPDATE_CFM = 91,
+    MM_MONITOR_REQ = 92,
+    MM_MONITOR_CFM = 93,
+    MM_MONITOR_CHANNEL_REQ = 94,
+    MM_MONITOR_CHANNEL_CFM = 95,
+    MM_FORCE_IDLE_REQ = 96,
+    MM_SCAN_CHANNEL_START_IND = 97,
+    MM_SCAN_CHANNEL_END_IND = 98,
+    MM_MAX = 99,
+}; // :69:6
+
+struct mm_monitor_cfm {
+    uint32_t status;
+    uint32_t enable;
+    uint32_t data[8];
+}; // :280:8
+
+struct mm_monitor_req {
+    uint32_t enable;
+}; // :288:8
+
+struct mm_monitor_channel_cfm {
+    uint32_t status;
+    uint32_t freq;
+    uint32_t data[8];
+}; // :294:8
+
+struct mm_monitor_channel_req {
+    uint32_t freq;
+    uint32_t use_40Mhz;
+    uint32_t higher_band;
+}; // :302:8
+
+struct mm_start_req {
+    struct phy_cfg_tag phy_cfg;
+    uint32_t uapsd_timeout;
+    uint16_t lp_clk_accuracy;
+}; // :310:8
+
+struct mm_set_channel_req {
+    uint8_t band;
+    uint8_t type;
+    uint16_t prim20_freq;
+    uint16_t center1_freq;
+    uint16_t center2_freq;
+    uint8_t index;
+    int8_t tx_power;
+}; // :321:8
+
+struct mm_set_channel_cfm {
+    uint8_t radio_idx;
+    int8_t power;
+}; // :342:8
+
+struct mm_set_dtim_req {
+    uint8_t dtim_period;
+}; // :351:8
+
+struct mm_set_power_req {
+    uint8_t inst_nbr;
+    int8_t power;
+}; // :358:8
+
+struct mm_set_power_cfm {
+    uint8_t radio_idx;
+    int8_t power;
+}; // :367:8
+
+struct mm_set_beacon_int_req {
+    uint16_t beacon_int;
+    uint8_t inst_nbr;
+}; // :376:8
+
+struct mm_set_basic_rates_req {
+    uint32_t rates;
+    uint8_t inst_nbr;
+    uint8_t band;
+}; // :385:8
+
+struct mm_set_bssid_req {
+    struct mac_addr bssid;
+    uint8_t inst_nbr;
+}; // :396:8
+
+struct mm_set_filter_req {
+    uint32_t filter;
+}; // :405:8
+
+struct mm_add_if_req {
+    uint8_t type;
+    struct mac_addr addr;
+    bool p2p;
+}; // :412:8
+
+struct mm_set_edca_req {
+    uint32_t ac_param;
+    bool uapsd;
+    uint8_t hw_queue;
+    uint8_t inst_nbr;
+}; // :423:8
+
+struct mm_set_slottime_req {
+    uint8_t slottime;
+}; // :436:8
+
+struct mm_set_mode_req {
+    uint8_t abgnmode;
+}; // :443:8
+
+struct mm_set_vif_state_req {
+    uint16_t aid;
+    bool active;
+    uint8_t inst_nbr;
+}; // :450:8
+
+struct mm_add_if_cfm {
+    uint8_t status;
+    uint8_t inst_nbr;
+}; // :461:8
+
+struct mm_remove_if_req {
+    uint8_t inst_nbr;
+}; // :470:8
+
+struct mm_version_cfm {
+    uint32_t version_lmac;
+    uint32_t version_machw_1;
+    uint32_t version_machw_2;
+    uint32_t version_phy_1;
+    uint32_t version_phy_2;
+    uint32_t features;
+}; // :477:8
+
+struct mm_sta_add_req {
+    uint32_t ampdu_size_max_vht;
+    uint32_t paid_gid;
+    uint16_t ampdu_size_max_ht;
+    struct mac_addr mac_addr;
+    uint8_t ampdu_spacing_min;
+    uint8_t inst_nbr;
+    bool tdls_sta;
+    int8_t rssi;
+    uint32_t tsflo;
+    uint32_t tsfhi;
+    uint8_t data_rate;
+}; // :494:8
+
+struct mm_sta_add_cfm {
+    uint8_t status;
+    uint8_t sta_idx;
+    uint8_t hw_sta_idx;
+}; // :517:8
+
+struct mm_sta_del_req {
+    uint8_t sta_idx;
+}; // :528:8
+
+struct mm_set_idle_req {
+    uint8_t hw_idle;
+}; // :542:8
+
+struct mm_key_add_req {
+    uint8_t key_idx;
+    uint8_t sta_idx;
+    struct mac_sec_key key;
+    uint8_t cipher_suite;
+    uint8_t inst_nbr;
+    uint8_t spp;
+    bool pairwise;
+}; // :549:8
+
+struct mm_key_add_cfm {
+    uint8_t status;
+    uint8_t hw_key_idx;
+}; // :568:8
+
+struct mm_key_del_req {
+    uint8_t hw_key_idx;
+}; // :577:8
+
+struct mm_ba_add_req {
+    uint8_t type;
+    uint8_t sta_idx;
+    uint8_t tid;
+    uint8_t bufsz;
+    uint16_t ssn;
+}; // :584:8
+
+struct mm_ba_add_cfm {
+    uint8_t sta_idx;
+    uint8_t tid;
+    uint8_t status;
+}; // :599:8
+
+struct mm_connection_loss_ind {
+    uint8_t inst_nbr;
+}; // :654:8
+
+struct mm_set_ps_mode_req {
+    uint8_t new_state;
+}; // :669:8
+
+struct mm_chan_ctxt_add_req {
+    uint8_t band;
+    uint8_t type;
+    uint16_t prim20_freq;
+    uint16_t center1_freq;
+    uint16_t center2_freq;
+    int8_t tx_power;
+}; // :682:8
+
+struct mm_chan_ctxt_update_req {
+    uint8_t chan_index;
+    uint8_t band;
+    uint8_t type;
+    uint16_t prim20_freq;
+    uint16_t center1_freq;
+    uint16_t center2_freq;
+    int8_t tx_power;
+}; // :735:8
+
+struct mm_bcn_change_req {
+    uint32_t bcn_ptr;
+    uint16_t bcn_len;
+    uint16_t tim_oft;
+    uint8_t tim_len;
+    uint8_t inst_nbr;
+    uint8_t csa_oft[2];
+    uint8_t bcn_buf[0];
+}; // :768:8
+
+struct mm_tim_update_req {
+    uint16_t aid;
+    uint8_t tx_avail;
+    uint8_t inst_nbr;
+}; // :787:8
+
+struct mm_ps_change_ind {
+    uint8_t sta_idx;
+    uint8_t ps_state;
+}; // :798:8
+
+struct mm_traffic_req_ind {
+    uint8_t sta_idx;
+    uint8_t pkt_cnt;
+    bool uapsd;
+}; // :816:8
+
+struct mm_remain_on_channel_req {
+    uint8_t op_code;
+    uint8_t vif_index;
+    uint8_t band;
+    uint8_t type;
+    uint16_t prim20_freq;
+    uint16_t center1_freq;
+    uint16_t center2_freq;
+    uint32_t duration_ms;
+    int8_t tx_power;
+}; // :828:8
+
+struct mm_remain_on_channel_cfm {
+    uint8_t op_code;
+    uint8_t status;
+    uint8_t chan_ctxt_index;
+}; // :851:8
+
+struct mm_set_ps_options_req {
+    uint8_t vif_index;
+    uint16_t listen_interval;
+    bool dont_listen_bc_mc;
+}; // :871:8
+
+struct mm_csa_counter_ind {
+    uint8_t vif_index;
+    uint8_t csa_count;
+}; // :882:8
+
+struct mm_cfg_rssi_req {
+    uint8_t vif_index;
+    int8_t rssi_thold;
+    uint8_t rssi_hyst;
+}; // :919:8
+
+struct mm_rssi_status_ind {
+    uint8_t vif_index;
+    bool rssi_status;
+    int8_t rssi;
+}; // :930:8
+
+struct mm_csa_finish_ind {
+    uint8_t vif_index;
+    uint8_t status;
+    uint8_t chan_idx;
+}; // :941:8
+
+struct mm_csa_traffic_ind {
+    uint8_t vif_index;
+    bool enable;
+}; // :952:8
+
+typedef void (*cb_idle_func_ptr)(void); // :961:16
+
+struct mm_force_idle_req {
+    cb_idle_func_ptr cb;
+}; // :964:8
+
+const struct ke_state_handler mm_state_handler[4]; // :1052:38
+const struct ke_state_handler mm_default_handler; // :1054:38
+ke_state_t mm_state[1]; // :1056:19
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/mm/mm_timer.c ======== */
+
+struct mm_timer_env_tag mm_timer_env; // :46:25
+
+void mm_timer_init(void); // :52:6
+static void mm_timer_hw_set(struct mm_timer_tag *timer); // :66:13
+static bool cmp_abs_time(const struct co_list_hdr *timerA, const struct co_list_hdr *timerB); // :104:12
+void mm_timer_set(struct mm_timer_tag *timer, uint32_t value); // :112:6
+void mm_timer_clear(struct mm_timer_tag *timer); // :159:6
+void mm_timer_schedule(int dummy); // :187:6
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/mm/mm_timer.h ======== */
+
+typedef void (*cb_timer_func_ptr)(void *); // :44:16
+
+struct mm_timer_tag {
+    struct co_list_hdr list_hdr;
+    cb_timer_func_ptr cb;
+    void *env;
+    uint32_t time;
+}; // :47:8
+
+struct mm_timer_env_tag {
+    struct co_list prog;
+}; // :60:8
+
+struct mm_timer_env_tag mm_timer_env; // :70:32
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/ps/ps.c ======== */
+
+struct ps_env_tag ps_env; // :54:19
+
+static uint8_t ps_send_pspoll(struct vif_info_tag *vif_entry); // :71:16
+static void ps_enable_cfm(void *env, uint32_t status); // :194:13
+static void ps_disable_cfm(void *env, uint32_t status); // :274:13
+static void ps_dpsm_update(bool pause); // :339:13
+static void ps_uapsd_timer_handle(void *env); // :425:13
+void ps_init(void); // :474:6
+void ps_set_mode(uint8_t mode, ke_task_id_t taskid); // :485:6
+void ps_polling_frame(struct vif_info_tag *vif_entry); // :636:6
+void ps_check_beacon(uint32_t tim, uint16_t len, struct vif_info_tag *vif_entry); // :643:6
+void ps_check_frame(uint8_t *frame, uint32_t statinfo, struct vif_info_tag *vif_entry); // :716:6
+void ps_check_tx_frame(uint8_t staid, uint8_t tid); // :844:6
+void ps_uapsd_set(struct vif_info_tag *vif_entry, uint8_t hw_queue, bool uapsd); // :898:6
+void ps_traffic_status_update(uint8_t vif_index, uint8_t new_status); // :923:6
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/ps/ps.h ======== */
+
+enum ps_dpsm_state_bit_pos {
+    PS_DPSM_STATE_ON = 0,
+    PS_DPSM_STATE_PAUSING = 1,
+    PS_DPSM_STATE_RESUMING = 2,
+    PS_DPSM_STATE_PAUSE = 3,
+    PS_DPSM_STATE_SET_MODE_REQ = 4,
+}; // :134:6
+
+struct ps_env_tag {
+    bool ps_on;
+    ke_task_id_t taskid;
+    uint32_t prevent_sleep;
+    uint8_t cfm_cnt;
+    struct mm_timer_tag uapsd_timer;
+    bool uapsd_tmr_on;
+    bool uapsd_on;
+    uint32_t uapsd_timeout;
+    uint8_t dpsm_state;
+    uint8_t next_mode;
+}; // :158:8
+
+struct ps_env_tag ps_env; // :192:26
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/rd/rd.h ======== */
+
+struct rd_env_tag {
+    struct co_list event_free_list;
+}; // :44:8
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/rx/rx_swdesc.c ======== */
+
+struct rx_swdesc rx_swdesc_tab[13]; // :40:18
+
+void rx_swdesc_init(void); // :46:6
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/rx/rx_swdesc.h ======== */
+
+struct rx_swdesc {
+    struct co_list_hdr list_hdr;
+    struct rx_dmadesc *dma_hdrdesc;
+    struct rx_payloaddesc *pd;
+    struct rx_pbd *last_pbd;
+    struct rx_pbd *spare_pbd;
+    uint32_t host_id;
+    uint32_t frame_len;
+    uint8_t status;
+    uint8_t pbd_count;
+    uint8_t use_in_tcpip;
+}; // :52:8
+
+struct rx_swdesc rx_swdesc_tab[13]; // :74:25
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/rx/rxl/rxl_cntrl.c ======== */
+
+struct rxl_cntrl_env_tag rxl_cntrl_env; // :121:26
+
+void rxl_dma_int_handler(void); // :860:6
+void rxl_dma_evt(int dummy); // :868:6
+void rxl_frame_release(struct rx_swdesc *swdesc); // :875:6
+void rxl_mpdu_free(struct rx_swdesc *swdesc); // :890:6
+void bl60x_firmwre_mpdu_free(void *swdesc_ptr); // :933:6
+void rxl_current_desc_get(struct rx_hd **rhd, struct rx_pbd **rbd); // :943:6
+void rxl_reset(void); // :952:6
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/rx/rxl/rxl_cntrl.h ======== */
+
+struct rxl_cntrl_env_tag {
+    struct co_list ready;
+    struct rx_dmadesc *first;
+    struct rx_dmadesc *last;
+    struct rx_dmadesc *free;
+    uint32_t packet_stack_cnt;
+}; // :90:8
+
+struct rxl_cntrl_env_tag rxl_cntrl_env; // :108:33
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/rx/rxl/rxl_hwdesc.c ======== */
+
+struct rxl_hwdesc_env_tag rx_hwdesc_env; // :36:27
+
+void rxl_hwdesc_dump(void); // :42:6
+void rxl_hwdesc_init(int init); // :93:6
+void rxl_hd_append(struct rx_dmadesc *desc); // :244:6
+void rxl_pd_append(struct rx_pbd *first, struct rx_pbd *last, struct rx_pbd *spare); // :293:6
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/rx/rxl/rxl_hwdesc.h ======== */
+
+struct rxl_hwdesc_env_tag {
+    struct rx_pbd *last;
+    struct rx_pbd *free;
+}; // :45:8
+
+struct rxl_hwdesc_env_tag rx_hwdesc_env; // :58:34
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/scan/scan.c ======== */
+
+struct scan_env_tag scan_env; // :43:21
+
+const struct scan_chan_tag *scan_get_chan(void); // :241:29
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/scan/scan.h ======== */
+
+struct scan_chan_tag {
+    uint16_t freq;
+    uint8_t band;
+    uint8_t flags;
+    int8_t tx_power;
+}; // :74:8
+
+struct scan_probe_req_ie_tag {
+    struct dma_desc dma_desc;
+    struct tx_pbd pbd;
+    uint32_t buf[50];
+}; // :87:8
+
+struct scan_env_tag {
+    struct hal_dma_desc_tag dma_desc;
+    const struct scan_start_req *param;
+    uint32_t ds_ie;
+    ke_task_id_t req_id;
+    uint8_t chan_idx;
+    bool abort;
+}; // :98:8
+
+struct scan_env_tag scan_env; // :119:28
+struct scan_probe_req_ie_tag scan_probe_req_ie; // :122:37
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/scan/scan_shared.c ======== */
+
+struct scan_probe_req_ie_tag scan_probe_req_ie; // :31:30
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/scan/scan_task.c ======== */
+
+static int scan_start_req_handler(const ke_msg_id_t msgid, const struct scan_start_req *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :55:1
+static int scan_cancel_req_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :113:1
+static int mm_scan_channel_start_ind_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :149:1
+static int mm_scan_channel_end_ind_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :190:1
+
+const struct ke_msg_handler scan_default_state[4]; // :242:29
+const struct ke_state_handler scan_default_handler; // :255:31
+ke_state_t scan_state[1]; // :259:12
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/scan/scan_task.h ======== */
+
+enum scan_state_tag {
+    SCAN_IDLE = 0,
+    SCAN_WAIT_IE_DWNLD = 1,
+    SCAN_WAIT_CHANNEL = 2,
+    SCAN_WAIT_BEACON_PROBE_RSP = 3,
+    SCAN_STATE_MAX = 4,
+}; // :47:6
+
+enum scan_msg_tag {
+    SCAN_START_REQ = 2048,
+    SCAN_START_CFM = 2049,
+    SCAN_DONE_IND = 2050,
+    SCAN_CANCEL_REQ = 2051,
+    SCAN_CANCEL_CFM = 2052,
+    SCAN_TIMER = 2053,
+    SCAN_MAX = 2054,
+}; // :62:6
+
+struct scan_start_req {
+    struct scan_chan_tag chan[42];
+    struct mac_ssid ssid[2];
+    struct mac_addr bssid;
+    uint32_t add_ies;
+    uint16_t add_ie_len;
+    uint8_t vif_idx;
+    uint8_t chan_cnt;
+    uint8_t ssid_cnt;
+    bool no_cck;
+}; // :85:8
+
+struct scan_start_cfm {
+    uint8_t status;
+}; // :109:8
+
+struct scan_cancel_cfm {
+    uint8_t status;
+}; // :116:8
+
+const struct ke_state_handler scan_default_handler; // :126:38
+ke_state_t scan_state[1]; // :128:19
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/sta/sta_mgmt.c ======== */
+
+struct sta_info_env_tag sta_info_env; // :54:25
+struct sta_info_tag sta_info_tab[12]; // :55:21
+
+static void sta_mgmt_entry_init(struct sta_info_tag *sta_entry); // :68:13
+void sta_mgmt_init(void); // :97:6
+uint8_t sta_mgmt_register(const struct mm_sta_add_req *param, uint8_t *sta_idx); // :149:9
+void sta_mgmt_unregister(uint8_t sta_idx); // :301:6
+void sta_mgmt_add_key(const struct mm_key_add_req *param, uint8_t hw_key_idx); // :367:6
+void sta_mgmt_del_key(struct sta_info_tag *sta); // :441:6
+int sta_mgmt_send_postponed_frame(struct vif_info_tag *p_vif_entry, struct sta_info_tag *p_sta_entry, int limit); // :456:5
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/sta/sta_mgmt.h ======== */
+
+enum sta_mgmt_pol_upd {
+    STA_MGMT_POL_UPD_RATE = 0,
+    STA_MGMT_POL_UPD_PROT = 1,
+    STA_MGMT_POL_UPD_PPDU_TX = 2,
+    STA_MGMT_POL_UPD_BW = 3,
+    STA_MGMT_POL_UPD_TX_POWER = 4,
+    STA_MGMT_POL_UPD_MAX = 5,
+}; // :94:6
+
+enum sta_ps_traffic {
+    PS_TRAFFIC_HOST = 1,
+    PS_TRAFFIC_INT = 2,
+    PS_TRAFFIC = 3,
+    UAPSD_TRAFFIC_HOST = 4,
+    UAPSD_TRAFFIC_INT = 8,
+    UAPSD_TRAFFIC = 12,
+}; // :111:6
+
+enum sta_ps_sp {
+    NO_SERVICE_PERIOD = 0,
+    PS_SERVICE_PERIOD = 1,
+    UAPSD_SERVICE_PERIOD_INT = 2,
+    UAPSD_SERVICE_PERIOD_HOST = 4,
+    UAPSD_SERVICE_PERIOD = 6,
+    ANY_SERVICE_PERIOD_INT = 3,
+    BCN_SERVICE_PERIOD = 8,
+}; // :129:6
+
+typedef int sta_ps_sp_t; // :146:13
+
+struct sta_mgmt_sec_info {
+    struct key_info_tag key_info;
+    struct key_info_tag *pairwise_key;
+    struct key_info_tag **cur_key;
+}; // :170:8
+
+struct sta_pol_tbl_cntl {
+    struct txl_buffer_control *buf_ctrl;
+    struct rc_sta_stats *sta_stats;
+    uint32_t prot_cfg;
+    uint16_t ppdu_tx_cfg;
+    uint8_t upd_field;
+}; // :186:8
+
+struct sta_mgmt_ba_info {
+    uint32_t last_tx_time;
+    uint32_t last_ba_add_time;
+    uint8_t bam_idx_rx;
+    uint8_t bam_idx_tx;
+    int8_t credit_oft;
+}; // :214:8
+
+struct sta_info_tag {
+    struct co_list_hdr list_hdr;
+    uint32_t bcn_int;
+    uint32_t ampdu_size_max_vht;
+    uint16_t ampdu_size_max_ht;
+    uint32_t paid_gid;
+    uint8_t ampdu_spacing_min;
+    uint16_t drift;
+    uint16_t aid;
+    uint8_t inst_nbr;
+    uint8_t staid;
+    uint8_t ps_state;
+    bool valid;
+    struct mac_addr mac_addr;
+    int8_t rssi;
+    uint32_t tsflo;
+    uint32_t tsfhi;
+    uint8_t data_rate;
+    uint8_t ctrl_port_state;
+    enum sta_ps_traffic traffic_avail;
+    sta_ps_sp_t ps_service_period;
+    uint16_t ctrl_port_ethertype;
+    struct sta_mgmt_sec_info sta_sec_info;
+    struct mac_sta_info info;
+    uint16_t seq_nbr[9];
+    struct sta_pol_tbl_cntl pol_tbl;
+    struct sta_mgmt_ba_info ba_info[9];
+    uint16_t rx_nqos_last_seqcntl;
+    uint16_t rx_qos_last_seqcntl[9];
+    struct co_list tx_desc_post;
+    void *suppData;
+    uint32_t time_last_seen;
+}; // :287:8
+
+struct sta_info_env_tag {
+    struct co_list free_sta_list;
+}; // :392:8
+
+struct sta_info_env_tag sta_info_env; // :410:32
+struct sta_info_tag sta_info_tab[12]; // :413:28
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/td/td.c ======== */
+
+struct td_env_tag td_env[2]; // :85:19
+
+static void td_timer_end(void *env); // :133:13
+void td_init(void); // :255:6
+void td_reset(uint8_t vif_index); // :276:6
+void td_start(uint8_t vif_index); // :315:6
+void td_pck_ind(uint8_t vif_index, uint8_t sta_index, bool rx); // :336:6
+void td_pck_ps_ind(uint8_t vif_index, bool rx); // :389:6
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/td/td.h ======== */
+
+enum td_status_bit {
+    TD_STATUS_TX = 0,
+    TD_STATUS_RX = 1,
+    TD_STATUS_TX_PS = 2,
+    TD_STATUS_RX_PS = 3,
+}; // :49:6
+
+struct td_env_tag {
+    struct mm_timer_tag td_timer;
+    uint32_t pck_cnt_tx;
+    uint32_t pck_cnt_rx;
+    uint32_t pck_cnt_tx_ps;
+    uint32_t pck_cnt_rx_ps;
+    uint8_t vif_index;
+    uint8_t status;
+    bool is_on;
+    bool has_active_chan;
+}; // :73:8
+
+struct td_env_tag td_env[2]; // :110:26
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/tpc/tpc.c ======== */
+
+void bl_tpc_update_power_table(int8_t *power_table); // :23:6
+void bl_tpc_power_table_get(int8_t *power_table_config); // :38:6
+void bl_tpc_update_power_table_rate(int8_t *power_table); // :49:6
+void bl_tpc_update_power_table_channel_offset(int8_t *power_table); // :54:6
+void bl_tpc_update_power_rate_11b(int8_t *power_rate_table); // :66:6
+void bl_tpc_update_power_rate_11g(int8_t *power_rate_table); // :71:6
+void bl_tpc_update_power_rate_11n(int8_t *power_rate_table); // :76:6
+void tpc_update_tx_power(int8_t pwr); // :82:6
+uint8_t tpc_get_vif_tx_power(struct vif_info_tag *vif); // :110:9
+void tpc_update_vif_tx_power(struct vif_info_tag *vif, int8_t *pwr, uint8_t *idx); // :115:6
+void tpc_update_frame_tx_power(struct vif_info_tag *vif, struct txl_frame_desc_tag *frame); // :175:6
+uint8_t tpc_get_vif_tx_power_vs_rate(uint32_t rate_config); // :195:9
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/tx/tx_swdesc.h ======== */
+
+struct hostdesc {
+    uint32_t pbuf_addr;
+    uint32_t packet_addr;
+    uint16_t packet_len;
+    uint32_t status_addr;
+    struct mac_addr eth_dest_addr;
+    struct mac_addr eth_src_addr;
+    uint16_t ethertype;
+    uint16_t pn[4];
+    uint16_t sn;
+    uint16_t timestamp;
+    uint8_t tid;
+    uint8_t vif_idx;
+    uint8_t staid;
+    uint16_t flags;
+    uint32_t pbuf_chained_ptr[4];
+    uint32_t pbuf_chained_len[4];
+}; // :59:8
+
+struct umacdesc {
+    struct txl_buffer_control *buf_control;
+    uint32_t buff_offset;
+    uint16_t payl_len;
+    uint8_t head_len;
+    uint8_t hdr_len_802_2;
+    uint8_t tail_len;
+}; // :95:8
+
+struct lmacdesc {
+    struct tx_agg_desc *agg_desc;
+    struct txl_buffer_tag *buffer;
+    struct tx_hw_desc *hw_desc;
+}; // :112:8
+
+struct txdesc {
+    struct co_list_hdr list_hdr;
+    struct hostdesc host;
+    struct umacdesc umac;
+    struct lmacdesc lmac;
+    struct tx_hw_desc hw_desc;
+    struct tx_cfm_tag hw_cfm;
+    uint32_t buf[128];
+}; // :123:8
+
+struct txdesc_host {
+    uint32_t ready;
+    struct hostdesc host;
+    uint32_t pad_txdesc[55];
+    uint32_t pad_buf[128];
+}; // :143:8
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/tx/txl/txl_buffer.c ======== */
+
+struct txl_buffer_env_tag txl_buffer_env; // :42:27
+
+void txl_buffer_reset(void); // :140:6
+struct txl_buffer_tag *txl_buffer_alloc(struct txdesc *txdesc, uint8_t access_category, uint8_t user_idx); // :146:24
+void txl_buffer_update_thd(struct txdesc *txdesc); // :183:6
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/tx/txl/txl_buffer.h ======== */
+
+struct txl_buffer_hw_desc_tag {
+    struct dma_desc dma_desc;
+    struct tx_pbd pbd;
+}; // :128:8
+
+struct txl_buffer_list_tag {
+    struct txl_buffer_tag *first;
+    struct txl_buffer_tag *last;
+}; // :137:8
+
+struct txl_buffer_idx_tag {
+    uint32_t used_area;
+    uint32_t free;
+    uint32_t free_size;
+    uint32_t last;
+    uint32_t next_needed;
+    uint32_t buf_size;
+    uint32_t *pool;
+    struct txl_buffer_hw_desc_tag *desc;
+    uint8_t count;
+}; // :146:8
+
+struct txl_buffer_control {
+    union {
+        struct tx_policy_tbl policy_tbl;
+        struct tx_compressed_policy_tbl comp_pol_tbl;
+    } ;
+    uint32_t mac_control_info;
+    uint32_t phy_control_info;
+}; // :171:8
+
+struct txl_buffer_env_tag {
+    struct txl_buffer_idx_tag buf_idx[5];
+    struct txl_buffer_list_tag list[5];
+}; // :198:8
+
+struct txl_buffer_tag {
+    uint32_t length;
+    uint32_t lenheader;
+    uint32_t lenpad;
+    uint32_t flags;
+    struct txl_buffer_tag *next;
+    struct txdesc *txdesc;
+    struct dma_desc dma_desc[1];
+    struct dma_desc dma_desc_pat;
+    struct tx_pbd tbd;
+    struct tx_pbd tbd_body[8];
+    uint8_t user_idx;
+    struct txl_buffer_control buffer_control;
+    struct tx_pbd tkip_mic_icv_pbd;
+    uint8_t tkip_mic_icv[12];
+    uint32_t payload[0];
+}; // :207:8
+
+struct txl_buffer_env_tag txl_buffer_env; // :247:34
+struct txl_buffer_control txl_buffer_control_desc[10]; // :251:34
+struct txl_buffer_control txl_buffer_control_desc_bcmc[2]; // :253:34
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/tx/txl/txl_buffer_shared.c ======== */
+
+struct txl_buffer_control txl_buffer_control_desc[10]; // :30:27
+struct txl_buffer_control txl_buffer_control_desc_bcmc[2]; // :31:27
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/tx/txl/txl_cfm.c ======== */
+
+struct txl_cfm_env_tag txl_cfm_env; // :59:24
+const uint32_t txl_cfm_evt_bit[5]; // :61:16
+
+void txl_cfm_dma_int_handler_backup(void); // :342:6
+void txl_cfm_evt(int access_category); // :349:6
+void txl_cfm_flush_desc(uint8_t access_category, struct txdesc *txdesc, uint32_t status); // :408:6
+void txl_cfm_flush(uint8_t access_category, struct co_list *list, uint32_t status); // :486:6
+void txl_cfm_dma_int_handler(void); // :576:6
+void txl_cfm_dump(void); // :597:6
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/tx/txl/txl_cfm.h ======== */
+
+const uint32_t txl_cfm_evt_bit[5]; // :59:23
+
+struct txl_cfm_env_tag {
+    struct co_list cfmlist[5];
+}; // :62:8
+
+struct txl_cfm_env_tag txl_cfm_env; // :73:31
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/tx/txl/txl_cntrl.c ======== */
+
+const uint16_t VHT_NDBPS[4]; // :155:16
+const uint32_t TX_TIMEOUT[5]; // :164:16
+struct txl_cntrl_env_tag txl_cntrl_env; // :179:26
+
+void txl_cntrl_inc_pck_cnt(void); // :2053:6
+bool txl_cntrl_push_int(struct txdesc *txdesc, uint8_t access_category); // :2063:5
+bool txl_cntrl_push_int_force(struct txdesc *txdesc, uint8_t access_category); // :2134:5
+void txl_payload_handle(void); // :2169:6
+void txl_payload_handle_backup(void); // :2193:6
+void txl_transmit_trigger(void); // :2288:6
+void txl_current_desc_get(int access_category, struct tx_hd **thd); // :2335:6
+void txl_reset(void); // :2384:6
+void txl_cntrl_env_dump(void); // :2501:6
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/tx/txl/txl_cntrl.h ======== */
+
+struct txl_list {
+    struct tx_hd *last_frame_exch;
+    struct co_list transmitting;
+    uint16_t bridgedmacnt;
+    uint8_t chk_state;
+}; // :200:8
+
+struct txl_cntrl_env_tag {
+    struct txl_list txlist[5];
+    uint32_t pck_cnt;
+    uint16_t seqnbr;
+    bool reset;
+}; // :238:8
+
+struct txl_cntrl_env_tag txl_cntrl_env; // :267:33
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/tx/txl/txl_frame.c ======== */
+
+static struct txl_frame_desc_tag txl_frame_desc[4]; // :55:34
+struct txl_frame_env_tag txl_frame_env; // :58:26
+
+void txl_frame_init_desc(struct txl_frame_desc_tag *frame, struct txl_buffer_tag *buffer, struct tx_hw_desc *hwdesc, struct txl_buffer_control *bufctrl); // :64:6
+void txl_frame_init(bool reset); // :96:6
+
+static uint32_t tx_count; // :249:17
+static uint32_t rx_count; // :250:17
+uint8_t mac_hw_reset; // :251:9
+
+struct txl_frame_desc_tag *txl_frame_get(int type, int len); // :252:28
+bool txl_frame_push(struct txl_frame_desc_tag *frame, uint8_t ac); // :379:5
+bool txl_frame_push_force(struct txl_frame_desc_tag *frame, uint8_t ac); // :422:5
+void txl_frame_cfm(struct txdesc *txdesc); // :448:6
+void txl_frame_release(struct txdesc *txdesc, bool postponed); // :457:6
+void txl_frame_evt(int dummy); // :480:6
+uint8_t txl_frame_send_null_frame(uint8_t sta_idx, cfm_func_ptr cfm, void *env); // :539:9
+uint8_t txl_frame_send_qosnull_frame(uint8_t sta_idx, uint16_t qos, cfm_func_ptr cfm, void *env); // :608:9
+uint8_t txl_frame_send_eapol_frame(uint8_t sta_idx, cfm_func_ptr cfm, void *cfm_env, uint8_t *pBuf, uint32_t pBuf_len); // :1340:9
+void txl_frame_dump(void); // :1495:6
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/tx/txl/txl_frame.h ======== */
+
+typedef void (*cfm_func_ptr)(void *, uint32_t); // :69:16
+
+struct txl_frame_cfm_tag {
+    cfm_func_ptr cfm_func;
+    void *env;
+}; // :72:8
+
+struct txl_frame_desc_tag {
+    struct txdesc txdesc;
+    struct txl_frame_cfm_tag cfm;
+    uint8_t type;
+    bool postponed;
+    bool keep_desc;
+}; // :81:8
+
+struct txl_frame_env_tag {
+    struct co_list desc_free;
+    struct co_list desc_done;
+}; // :97:8
+
+struct txl_frame_env_tag txl_frame_env; // :111:33
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/tx/txl/txl_frame_shared.c ======== */
+
+uint32_t txl_frame_pool[4]; // :40:10
+uint8_t txl_tim_ie_pool[2]; // :43:9
+uint8_t txl_tim_bitmap_pool[2]; // :44:9
+struct tx_pbd txl_tim_desc[2]; // :45:15
+uint32_t txl_bcn_pool[2]; // :46:10
+struct tx_hw_desc txl_bcn_hwdesc_pool[2]; // :47:19
+struct tx_cfm_tag txl_bcn_hwdesc_cfms[2]; // :48:19
+struct tx_pbd txl_bcn_end_desc[2]; // :49:15
+struct txl_buffer_control txl_bcn_buf_ctrl[2]; // :51:27
+struct tx_hw_desc txl_frame_hwdesc_pool[4]; // :68:19
+struct tx_cfm_tag txl_frame_hwdesc_cfms[4]; // :69:19
+struct txl_buffer_control txl_buffer_control_24G; // :73:27
+struct txl_buffer_control txl_buffer_control_5G; // :75:27
+struct txl_buffer_control txl_frame_buf_ctrl[4]; // :96:27
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/tx/txl/txl_hwdesc.c ======== */
+
+void txl_hwdesc_reset(void); // :138:6
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/vif/vif_mgmt.c ======== */
+
+struct vif_mgmt_env_tag vif_mgmt_env; // :60:25
+struct vif_info_tag vif_info_tab[2]; // :61:21
+
+static void vif_mgmt_bcn_to_evt(void *env); // :76:13
+void vif_mgmt_init(void); // :121:6
+void vif_mgmt_reset(void); // :144:6
+uint8_t vif_mgmt_register(const struct mac_addr *mac_addr, uint8_t vif_type, bool p2p, uint8_t *vif_idx); // :158:9
+void vif_mgmt_unregister(uint8_t vif_idx); // :388:6
+void vif_mgmt_add_key(const struct mm_key_add_req *param, uint8_t hw_key_idx); // :486:6
+void vif_mgmt_del_key(struct vif_info_tag *vif, uint8_t keyid); // :542:6
+void vif_mgmt_send_postponed_frame(struct vif_info_tag *p_vif_entry); // :583:6
+void vif_mgmt_bcn_to_prog(struct vif_info_tag *p_vif_entry); // :622:6
+void vif_mgmt_bcn_recv(struct vif_info_tag *p_vif_entry); // :627:6
+void vif_mgmt_set_ap_bcn_int(struct vif_info_tag *p_vif_entry, uint16_t bcn_int); // :660:6
+void vif_mgmt_switch_channel(struct vif_info_tag *p_vif_entry); // :728:6
+struct vif_info_tag *vif_mgmt_get_first_ap_inf(void); // :803:23
+
+/* ======== components/bl602/bl602_wifi/ip/lmac/src/vif/vif_mgmt.h ======== */
+
+enum VIF_AP_BCMC_STATUS {
+    VIF_AP_BCMC_BUFFERED = 1,
+    VIF_AP_BCMC_MOREDATA = 2,
+}; // :83:6
+
+struct vif_info_tag {
+    struct co_list_hdr list_hdr;
+    uint32_t prevent_sleep;
+    uint32_t txq_params[4];
+    struct mm_timer_tag tbtt_timer;
+    struct mm_timer_tag tmr_bcn_to;
+    struct mac_addr bssid;
+    struct chan_ctxt_tag *chan_ctxt;
+    struct chan_tbtt_tag tbtt_switch;
+    struct mac_addr mac_addr;
+    uint8_t type;
+    uint8_t index;
+    bool active;
+    int8_t tx_power;
+    int8_t user_tx_power;
+    union {
+        struct {
+            uint16_t listen_interval;
+            bool dont_wait_bcmc;
+            uint8_t ps_retry;
+            uint8_t ap_id;
+            uint32_t uapsd_last_rxtx;
+            uint8_t uapsd_queues;
+            uint32_t mon_last_tx;
+            uint32_t mon_last_crc;
+            uint8_t beacon_loss_cnt;
+            int8_t rssi;
+            int8_t rssi_thold;
+            uint8_t rssi_hyst;
+            bool rssi_status;
+            uint8_t csa_count;
+            bool csa_occured;
+        } sta;
+        struct {
+            uint32_t dummy;
+            struct txl_frame_desc_tag bcn_desc;
+            uint16_t bcn_len;
+            uint16_t tim_len;
+            uint16_t tim_bitmap_set;
+            uint16_t bcn_int;
+            uint8_t bcn_tbtt_ratio;
+            uint8_t bcn_tbtt_cnt;
+            bool bcn_configured;
+            uint8_t dtim_count;
+            uint8_t tim_n1;
+            uint8_t tim_n2;
+            uint8_t bc_mc_status;
+            uint8_t csa_count;
+            uint8_t csa_oft[2];
+            uint8_t ps_sta_cnt;
+            uint16_t ctrl_port_ethertype;
+        } ap;
+    } u;
+    struct co_list sta_list;
+    struct mac_bss_info bss_info;
+    struct key_info_tag key_info[4];
+    struct key_info_tag *default_key;
+    uint32_t flags;
+    struct mm_chan_ctxt_add_req csa_channel;
+}; // :93:8
+
+struct vif_mgmt_env_tag {
+    struct co_list free_list;
+    struct co_list used_list;
+    uint8_t vif_sta_cnt;
+    uint8_t vif_ap_cnt;
+    uint8_t low_bcn_int_idx;
+}; // :314:8
+
+struct vif_mgmt_env_tag vif_mgmt_env; // :350:32
+struct vif_info_tag vif_info_tab[2]; // :353:28
+
+/* ======== components/bl602/bl602_wifi/ip/umac/src/apm/apm.c ======== */
+
+struct apm apm_env; // :41:12
+
+void apm_init(void); // :62:6
+void apm_start_cfm(uint8_t status); // :75:6
+void apm_set_bss_param(void); // :138:6
+void apm_send_next_bss_param(void); // :186:6
+void apm_bcn_set(void); // :197:6
+void apm_stop(struct vif_info_tag *vif); // :227:6
+bool apm_tx_int_ps_check(struct txdesc *txdesc); // :265:5
+void apm_tx_int_ps_postpone(struct txdesc *txdesc, struct sta_info_tag *sta); // :283:6
+struct txdesc *apm_tx_int_ps_get_postpone(struct vif_info_tag *vif, struct sta_info_tag *sta, int *stop); // :320:16
+void apm_tx_int_ps_clear(struct vif_info_tag *vif, uint8_t sta_idx); // :429:6
+static int _aid_list_delete(uint8_t *mac); // :457:12
+static void apm_sta_delete(uint8_t sta_idx, uint8_t *mac); // :522:13
+void apm_sta_fw_delete(uint8_t sta_idx); // :549:6
+void apm_sta_add(uint8_t sta_idx); // :555:6
+void apm_tx_cfm_handler(void *env, uint32_t status); // :576:6
+void apm_send_mlme(struct vif_info_tag *vif, uint16_t fctl, const struct mac_addr *ra, cfm_func_ptr cfm_func, void *env, uint16_t status_code); // :599:6
+bool apm_embedded_enabled(struct vif_info_tag *vif); // :671:5
+void apm_probe_req_handler(const struct rxu_mgt_ind *param); // :679:6
+void apm_auth_handler(const struct rxu_mgt_ind *param); // :744:6
+void apm_assoc_req_handler(const struct rxu_mgt_ind *param, bool is_reassoc); // :768:6
+void apm_deauth_handler(const struct rxu_mgt_ind *param); // :991:6
+void apm_disassoc_handler(const struct rxu_mgt_ind *param); // :1002:6
+void apm_beacon_handler(const struct rxu_mgt_ind *param); // :1017:6
+void apm_sta_remove(uint8_t vif_idx, uint8_t sta_idx); // :1022:6
+
+/* ======== components/bl602/bl602_wifi/ip/umac/src/apm/apm.h ======== */
+
+struct apm {
+    const struct apm_start_req *param;
+    struct co_list bss_config;
+    uint8_t aging_sta_idx;
+    uint8_t *bcn_buf;
+    bool apm_emb_enabled;
+    uint8_t hidden_ssid;
+    uint8_t assoc_sta_count;
+    uint8_t max_sta_supported;
+    struct {
+        uint8_t mac[6];
+        uint8_t used;
+    } aid_list[10];
+}; // :32:8
+
+struct apm apm_env; // :205:19
+
+/* ======== components/bl602/bl602_wifi/ip/umac/src/apm/apm_task.c ======== */
+
+static int apm_start_req_handler(const ke_msg_id_t msgid, struct apm_start_req *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :65:1
+static int me_set_ps_disable_cfm_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :231:1
+static int mm_bss_param_setting_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :266:1
+static int me_set_active_cfm_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :296:1
+static int mm_bcn_change_cfm_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :336:1
+static int apm_stop_req_handler(const ke_msg_id_t msgid, const struct apm_stop_req *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :365:1
+static int apm_conf_max_sta_req_handler(const ke_msg_id_t msgid, const struct apm_conf_max_sta_req *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :429:1
+static int apm_start_cac_req_handler(const ke_msg_id_t msgid, const struct apm_start_cac_req *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :461:1
+static int apm_stop_cac_req_handler(const ke_msg_id_t msgid, const struct apm_stop_cac_req *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :544:1
+static int apm_sta_del_req_handler(const ke_msg_id_t msgid, const struct apm_sta_del_req *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :586:1
+static int apm_sta_add_cfm_handler(const ke_msg_id_t msgid, const struct me_sta_add_cfm *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :636:1
+static int rxu_mgt_ind_handler(const ke_msg_id_t msgid, const struct rxu_mgt_ind *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :668:1
+static int apm_sta_connect_timeout_ind_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :709:1
+
+const struct ke_msg_handler apm_default_state[16]; // :734:29
+const struct ke_state_handler apm_default_handler; // :757:31
+ke_state_t apm_state[1]; // :761:12
+
+/* ======== components/bl602/bl602_wifi/ip/umac/src/apm/apm_task.h ======== */
+
+enum apm_state_tag {
+    APM_IDLE = 0,
+    APM_BSS_PARAM_SETTING = 1,
+    APM_BCN_SETTING = 2,
+    APM_STATE_MAX = 3,
+}; // :40:6
+
+enum apm_msg_tag {
+    APM_START_REQ = 7168,
+    APM_START_CFM = 7169,
+    APM_STOP_REQ = 7170,
+    APM_STOP_CFM = 7171,
+    APM_START_CAC_REQ = 7172,
+    APM_START_CAC_CFM = 7173,
+    APM_STOP_CAC_REQ = 7174,
+    APM_STOP_CAC_CFM = 7175,
+    APM_STA_ADD_IND = 7176,
+    APM_STA_DEL_IND = 7177,
+    APM_STA_CONNECT_TIMEOUT_IND = 7178,
+    APM_STA_DEL_REQ = 7179,
+    APM_STA_DEL_CFM = 7180,
+    APM_CONF_MAX_STA_REQ = 7181,
+    APM_CONF_MAX_STA_CFM = 7182,
+}; // :53:6
+
+struct apm_start_req {
+    struct mac_rateset basic_rates;
+    struct scan_chan_tag chan;
+    uint32_t center_freq1;
+    uint32_t center_freq2;
+    uint8_t ch_width;
+    uint8_t hidden_ssid;
+    uint32_t bcn_addr;
+    uint16_t bcn_len;
+    uint16_t tim_oft;
+    uint16_t bcn_int;
+    uint32_t flags;
+    uint16_t ctrl_port_ethertype;
+    uint8_t tim_len;
+    uint8_t vif_idx;
+    bool apm_emb_enabled;
+    struct mac_rateset rate_set;
+    uint8_t beacon_period;
+    uint8_t qos_supported;
+    struct mac_ssid ssid;
+    uint8_t ap_sec_type;
+    uint8_t phrase[64];
+    uint8_t bcn_buf[];
+}; // :88:8
+
+struct apm_start_cfm {
+    uint8_t status;
+    uint8_t vif_idx;
+    uint8_t ch_idx;
+    uint8_t bcmc_idx;
+}; // :139:8
+
+struct apm_stop_req {
+    uint8_t vif_idx;
+}; // :152:8
+
+struct apm_conf_max_sta_req {
+    uint8_t max_sta_supported;
+}; // :159:8
+
+struct apm_start_cac_req {
+    struct scan_chan_tag chan;
+    uint32_t center_freq1;
+    uint32_t center_freq2;
+    uint8_t ch_width;
+    uint8_t vif_idx;
+}; // :166:8
+
+struct apm_start_cac_cfm {
+    uint8_t status;
+    uint8_t ch_idx;
+}; // :181:8
+
+struct apm_stop_cac_req {
+    uint8_t vif_idx;
+}; // :190:8
+
+struct apm_sta_del_req {
+    uint8_t vif_idx;
+    uint8_t sta_idx;
+}; // :196:8
+
+struct apm_sta_del_cfm {
+    uint8_t status;
+    uint8_t vif_idx;
+    uint8_t sta_idx;
+}; // :205:8
+
+struct apm_sta_add_ind {
+    uint32_t flags;
+    struct mac_addr sta_addr;
+    uint8_t vif_idx;
+    uint8_t sta_idx;
+    int8_t rssi;
+    uint32_t tsflo;
+    uint32_t tsfhi;
+    uint8_t data_rate;
+}; // :216:8
+
+struct apm_sta_del_ind {
+    uint8_t sta_idx;
+}; // :233:8
+
+const struct ke_state_handler apm_default_handler; // :239:38
+ke_state_t apm_state[1]; // :241:19
+
+/* ======== components/bl602/bl602_wifi/ip/umac/src/bam/bam.c ======== */
+
+struct bam_env_tag bam_env[1]; // :43:20
+
+void bam_init(void); // :335:6
+void bam_send_air_action_frame(uint8_t sta_idx, struct bam_env_tag *bam_env, uint8_t action, uint8_t dialog_token, uint16_t param, uint16_t status_code, void (*cfm_func)(void *, uint32_t)); // :493:6
+
+/* ======== components/bl602/bl602_wifi/ip/umac/src/bam/bam.h ======== */
+
+typedef unsigned int (*bam_baw_index_func_ptr)(struct bam_baw *, unsigned int); // :192:24
+
+struct bam_baw {
+    bam_baw_index_func_ptr idx_compute;
+    uint16_t fsn;
+    uint8_t states[64];
+    uint8_t fsn_idx;
+    uint8_t buf_size;
+    uint8_t mask;
+}; // :272:8
+
+struct bam_env_tag {
+    uint32_t pkt_cnt;
+    uint32_t last_activity_time;
+    uint16_t ssn;
+    uint16_t ba_timeout;
+    uint8_t sta_idx;
+    uint8_t dev_type;
+    uint8_t ba_policy;
+    uint8_t buffer_size;
+    uint8_t tid;
+    uint8_t dialog_token;
+    uint8_t amsdu;
+    uint8_t delba_count;
+    struct bam_baw baw;
+}; // :288:8
+
+struct bam_env_tag bam_env[1]; // :324:27
+
+/* ======== components/bl602/bl602_wifi/ip/umac/src/bam/bam_task.c ======== */
+
+static int rxu_mgt_ind_handler(const ke_msg_id_t msgid, const struct rxu_mgt_ind *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :334:12
+
+const struct ke_msg_handler bam_default_state[1]; // :603:29
+const struct ke_state_handler bam_default_handler; // :618:31
+ke_state_t bam_state[1]; // :621:12
+
+/* ======== components/bl602/bl602_wifi/ip/umac/src/bam/bam_task.h ======== */
+
+enum bam_state_tag {
+    BAM_IDLE = 0,
+    BAM_ACTIVE = 1,
+    BAM_WAIT_RSP = 2,
+    BAM_CHECK_ADMISSION = 3,
+    BAM_RESET = 4,
+    BAM_STATE_MAX = 5,
+}; // :35:6
+
+const struct ke_state_handler bam_default_handler; // :67:38
+ke_state_t bam_state[1]; // :68:19
+
+/* ======== components/bl602/bl602_wifi/ip/umac/src/hostapd/hostapd_api.c ======== */
+
+int bl606fw_send_mlme(void *priv, const uint8_t *frm, size_t data_len, int noack, unsigned int freq, const uint16_t *csa_offs, size_t csa_offs_len); // :13:5
+
+/* ======== components/bl602/bl602_wifi/ip/umac/src/hostapd/hostapd_task.c ======== */
+
+static int hostapd_mgt_ind_handler(const ke_msg_id_t msgid, const struct rxu_mgt_ind *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :24:12
+
+static const struct ke_msg_handler hostapd_default_state[1]; // :42:36
+const struct ke_state_handler hostapd_default_handler; // :47:31
+ke_state_t hostapd_u_state[1]; // :50:12
+
+/* ======== components/bl602/bl602_wifi/ip/umac/src/hostapd/hostapd_task.h ======== */
+
+enum hostapd_state_tag {
+    HOSTAPD_STATE_IDLE = 0,
+    HOSTAPD_STATE_MAX = 1,
+}; // :6:6
+
+const struct ke_state_handler hostapd_default_handler; // :12:38
+ke_state_t hostapd_u_state[1]; // :13:19
+
+/* ======== components/bl602/bl602_wifi/ip/umac/src/llc/llc.h ======== */
+
+struct llc_snap_short {
+    uint16_t dsap_ssap;
+    uint16_t control_oui0;
+    uint16_t oui1_2;
+}; // :89:8
+
+struct llc_snap {
+    uint16_t dsap_ssap;
+    uint16_t control_oui0;
+    uint16_t oui1_2;
+    uint16_t proto_id;
+}; // :100:8
+
+/* ======== components/bl602/bl602_wifi/ip/umac/src/me/me.c ======== */
+
+struct me_env_tag me_env; // :44:19
+
+void me_init(void); // :70:6
+struct scan_chan_tag *me_freq_to_chan_ptr(uint8_t band, uint16_t freq); // :99:23
+
+/* ======== components/bl602/bl602_wifi/ip/umac/src/me/me.h ======== */
+
+struct me_env_tag {
+    uint32_t active_vifs;
+    uint32_t ps_disable_vifs;
+    ke_task_id_t requester_id;
+    struct mac_htcapability ht_cap;
+    uint16_t tx_lft;
+    bool ht_supported;
+    struct me_chan_config_req chan;
+    uint8_t stbc_nss;
+    uint8_t phy_bw_max;
+    bool ps_on;
+}; // :66:8
+
+struct mobility_domain {
+    uint16_t mdid;
+    uint8_t ft_capability_policy;
+}; // :99:8
+
+struct mac_bss_info {
+    struct mac_htcapability ht_cap;
+    struct mac_addr bssid;
+    struct mac_ssid ssid;
+    uint16_t bsstype;
+    struct scan_chan_tag *chan;
+    uint16_t center_freq1;
+    uint16_t center_freq2;
+    uint16_t beacon_period;
+    uint16_t cap_info;
+    struct mac_rateset rate_set;
+    struct mac_edca_param_set edca_param;
+    int8_t rssi;
+    int8_t ppm_rel;
+    int8_t ppm_abs;
+    uint8_t high_11b_rate;
+    uint16_t prot_status;
+    uint8_t bw;
+    uint8_t phy_bw;
+    uint8_t power_constraint;
+    uint32_t valid_flags;
+    struct mobility_domain mde;
+    bool is_supplicant_enabled;
+    SecurityMode_t wpa_wpa2_wep;
+    Cipher_t wpa_mcstCipher;
+    Cipher_t wpa_ucstCipher;
+    Cipher_t rsn_mcstCipher;
+    Cipher_t rsn_ucstCipher;
+    bool is_pmf_required;
+    bool is_wpa2_prefered;
+    uint8_t rsn_wpa_ie[32];
+    uint8_t rsn_wpa_ie_len;
+    uint16_t beacon_interval;
+    uint16_t aid_bitmap;
+    uint16_t max_listen_interval;
+    uint8_t sec_type;
+}; // :108:8
+
+struct me_env_tag me_env; // :188:26
+
+/* ======== components/bl602/bl602_wifi/ip/umac/src/me/me_mgmtframe.c ======== */
+
+uint32_t me_add_ie_ssid(uint32_t *frame_addr, uint8_t ssid_len, uint8_t *p_ssid); // :119:10
+uint32_t me_add_ie_supp_rates(uint32_t *frame_addr, struct mac_rateset *p_rateset); // :142:10
+uint32_t me_add_ie_ext_supp_rates(uint32_t *frame_addr, struct mac_rateset *p_rateset); // :164:10
+uint32_t me_add_ie_ds(uint32_t *frame_addr, uint8_t channel); // :187:10
+uint32_t me_add_ie_erp(uint32_t *frame_addr, uint8_t erp_info); // :207:10
+uint32_t me_add_ie_rsn(uint32_t *frame_addr, uint8_t enc_type); // :227:10
+uint32_t me_add_ie_wpa(uint32_t *frame_addr, uint8_t enc_type); // :285:10
+uint32_t me_add_ie_tim(uint32_t *frame_addr, uint8_t dtim_period); // :321:10
+uint32_t me_add_ie_ht_capa(uint32_t *frame_addr); // :364:10
+uint32_t me_add_ie_ht_oper(uint32_t *frame_addr, struct vif_info_tag *p_vif_entry); // :393:10
+uint16_t me_build_authenticate(uint32_t frame, uint16_t algo_type, uint16_t seq_nbr, uint16_t status_code, uint32_t *challenge_array_ptr); // :554:10
+uint16_t me_build_deauthenticate(uint32_t frame, uint16_t reason_code); // :602:10
+uint16_t me_build_associate_req(uint32_t frame, struct mac_bss_info *bss, struct mac_addr *old_ap_addr_ptr, uint8_t vif_idx, uint32_t *ie_addr, uint16_t *ie_len, const struct sm_connect_req *con_par); // :613:10
+uint16_t me_build_add_ba_req(uint32_t frame, struct bam_env_tag *bam_env); // :821:10
+uint16_t me_build_add_ba_rsp(uint32_t frame, struct bam_env_tag *bam_env, uint16_t param, uint8_t dialog_token, uint16_t status_code); // :838:10
+uint16_t me_build_del_ba(uint32_t frame, struct bam_env_tag *bam_env, uint16_t reason_code); // :864:10
+void me_extract_rate_set(uint32_t buffer, uint16_t buflen, struct mac_rateset *mac_rate_set_ptr); // :879:6
+void me_extract_power_constraint(uint32_t buffer, uint16_t buflen, struct mac_bss_info *bss); // :934:6
+void me_extract_country_reg(uint32_t buffer, uint16_t buflen, struct mac_bss_info *bss); // :950:6
+void me_extract_mobility_domain(uint32_t buffer, uint16_t buflen, struct mac_bss_info *bss); // :997:6
+int me_extract_csa(uint32_t buffer, uint16_t buflen, uint8_t *mode, struct mm_chan_ctxt_add_req *chan_desc); // :1015:5
+uint16_t me_build_beacon(uint32_t frame, uint8_t vif_idx, uint16_t *tim_oft, uint8_t *tim_len, uint8_t hidden_ssid); // :1121:10
+uint16_t me_build_probe_rsp(uint32_t frame, uint8_t vif_idx); // :1219:10
+uint16_t me_build_associate_rsp(uint32_t frame, uint8_t vif_idx, uint16_t status_code, struct me_sta_add_req *req); // :1294:10
+
+/* ======== components/bl602/bl602_wifi/ip/umac/src/me/me_mic.c ======== */
+
+static void michael_block(struct mic_calc *mic_calc_ptr, uint32_t block); // :156:13
+void me_mic_init(struct mic_calc *mic_calc_ptr, uint32_t *mic_key_ptr, struct mac_addr *da, struct mac_addr *sa, uint8_t tid); // :340:6
+void me_mic_calc(struct mic_calc *mic_calc_ptr, uint32_t start_ptr, uint32_t data_len); // :366:6
+void me_mic_end(struct mic_calc *mic_calc_ptr); // :379:6
+
+/* ======== components/bl602/bl602_wifi/ip/umac/src/me/me_mic.h ======== */
+
+struct mic_calc {
+    uint32_t mic_key_least;
+    uint32_t mic_key_most;
+    uint32_t last_m_i;
+    uint8_t last_m_i_len;
+}; // :41:8
+
+/* ======== components/bl602/bl602_wifi/ip/umac/src/me/me_task.c ======== */
+
+static int me_config_req_handler(const ke_msg_id_t msgid, const struct me_config_req *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :44:1
+static int me_chan_config_req_handler(const ke_msg_id_t msgid, const struct me_chan_config_req *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :143:1
+static int me_set_control_port_req_handler(const ke_msg_id_t msgid, const struct me_set_control_port_req *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :172:1
+static int me_sta_add_req_handler(const ke_msg_id_t msgid, const struct me_sta_add_req *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :221:1
+static int me_sta_del_req_handler(const ke_msg_id_t msgid, const struct me_sta_del_req *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :421:1
+static int me_traffic_ind_req_handler(const ke_msg_id_t msgid, const struct me_traffic_ind_req *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :467:1
+static int me_set_active_req_handler(const ke_msg_id_t msgid, const struct me_set_active_req *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :530:1
+static int mm_set_idle_cfm_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :588:1
+static int me_set_ps_disable_req_handler(const ke_msg_id_t msgid, const struct me_set_ps_disable_req *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :620:1
+static int mm_set_ps_mode_cfm_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :693:1
+static int me_rc_stats_req_handler(const ke_msg_id_t msgid, const struct me_rc_stats_req *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :725:1
+static int me_rc_set_rate_req_handler(const ke_msg_id_t msgid, const struct me_rc_set_rate_req *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :789:1
+
+const struct ke_msg_handler me_default_state[15]; // :825:29
+const struct ke_state_handler me_default_handler; // :848:31
+ke_state_t me_state[1]; // :852:12
+
+/* ======== components/bl602/bl602_wifi/ip/umac/src/me/me_task.h ======== */
+
+struct me_config_req {
+    struct mac_htcapability ht_cap;
+    struct mac_vhtcapability vht_cap;
+    uint16_t tx_lft;
+    bool ht_supp;
+    bool vht_supp;
+    bool ps_on;
+}; // :96:8
+
+struct me_chan_config_req {
+    struct scan_chan_tag chan2G4[14];
+    struct scan_chan_tag chan5G[28];
+    uint8_t chan2G4_cnt;
+    uint8_t chan5G_cnt;
+}; // :113:8
+
+struct me_set_control_port_req {
+    uint8_t sta_idx;
+    bool control_port_open;
+}; // :126:8
+
+struct me_tkip_mic_failure_ind {
+    struct mac_addr addr;
+    uint64_t tsc;
+    bool ga;
+    uint8_t keyid;
+    uint8_t vif_idx;
+}; // :135:8
+
+struct me_sta_add_req {
+    struct mac_addr mac_addr;
+    struct mac_rateset rate_set;
+    struct mac_htcapability ht_cap;
+    struct mac_vhtcapability vht_cap;
+    uint32_t flags;
+    uint16_t aid;
+    uint8_t uapsd_queues;
+    uint8_t max_sp_len;
+    uint8_t opmode;
+    uint8_t vif_idx;
+    bool tdls_sta;
+    uint32_t tsflo;
+    uint32_t tsfhi;
+    int8_t rssi;
+    uint8_t data_rate;
+}; // :150:8
+
+struct me_sta_add_cfm {
+    uint8_t sta_idx;
+    uint8_t status;
+    uint8_t pm_state;
+}; // :182:8
+
+struct me_sta_del_req {
+    uint8_t sta_idx;
+    bool tdls_sta;
+}; // :193:8
+
+struct me_set_active_req {
+    bool active;
+    uint8_t vif_idx;
+}; // :213:8
+
+struct me_set_ps_disable_req {
+    bool ps_disable;
+    uint8_t vif_idx;
+}; // :222:8
+
+struct me_traffic_ind_req {
+    uint8_t sta_idx;
+    uint8_t tx_avail;
+    bool uapsd;
+}; // :231:8
+
+struct me_rc_stats_req {
+    uint8_t sta_idx;
+}; // :242:8
+
+struct me_rc_stats_cfm {
+    uint8_t sta_idx;
+    uint16_t no_samples;
+    uint16_t ampdu_len;
+    uint16_t ampdu_packets;
+    uint32_t avg_ampdu_len;
+    uint8_t sw_retry_step;
+    uint8_t sample_wait;
+    struct step retry[4];
+    struct rc_rate_stats rate_stats[10];
+    uint32_t tp[10];
+}; // :249:8
+
+struct me_rc_set_rate_req {
+    uint8_t sta_idx;
+    uint16_t fixed_rate_cfg;
+}; // :274:8
+
+const struct ke_state_handler me_default_handler; // :282:38
+ke_state_t me_state[1]; // :284:19
+
+/* ======== components/bl602/bl602_wifi/ip/umac/src/me/me_utils.c ======== */
+
+bool me_set_sta_ht_vht_param(struct sta_info_tag *sta, struct mac_bss_info *bss); // :72:5
+uint8_t me_11ac_mcs_max(uint16_t mcs_map); // :122:9
+uint8_t me_11ac_nss_max(uint16_t mcs_map); // :145:9
+uint8_t me_11n_nss_max(uint8_t *mcs_set); // :159:9
+uint8_t me_legacy_ridx_min(uint16_t rate_map); // :173:9
+uint8_t me_legacy_ridx_max(uint16_t rate_map); // :188:9
+uint8_t me_rate_translate(uint8_t rate); // :373:9
+void me_get_basic_rates(const struct mac_rateset *rateset, struct mac_rateset *basic_ratest); // :422:6
+uint16_t me_legacy_rate_bitfield_build(const struct mac_rateset *rateset, bool basic_only); // :438:10
+uint16_t me_rate_bitfield_vht_build(uint16_t mcs_map_1, uint16_t mcs_map_2); // :466:10
+uint16_t me_build_capability(uint8_t vif_idx); // :489:10
+void me_init_rate(struct sta_info_tag *sta_entry); // :539:6
+void me_init_bcmc_rate(struct sta_info_tag *sta_entry); // :546:6
+void me_tx_cfm_singleton(struct txdesc *txdesc); // :566:6
+void me_tx_cfm_ampdu(uint8_t sta_idx, uint32_t txed, uint32_t txok, bool retry_required); // :588:6
+void me_check_rc(uint8_t sta_idx, bool *tx_ampdu); // :594:6
+struct txl_buffer_control *me_update_buffer_control(struct sta_info_tag *sta_info); // :600:28
+void me_bw_check(uint32_t ht_op_addr, uint32_t vht_op_addr, struct mac_bss_info *bss); // :816:6
+void me_beacon_check(uint8_t vif_idx, uint16_t length, uint32_t bcn_addr); // :892:6
+void me_sta_bw_nss_max_upd(uint8_t sta_idx, uint8_t bw, uint8_t nss); // :1042:6
+uint16_t me_tx_cfm_amsdu(struct txdesc *txdesc); // :1084:10
+uint8_t me_add_chan_ctx(uint8_t *p_chan_idx, struct scan_chan_tag *p_chan, uint32_t center_freq1, uint32_t center_freq2, uint8_t ch_width); // :1108:9
+
+/* ======== components/bl602/bl602_wifi/ip/umac/src/rc/rc.c ======== */
+
+struct rc_sta_stats sta_stats[10]; // :38:21
+static const uint32_t rc_duration_ht_ampdu[80]; // :44:23
+static const uint32_t rc_duration_cck[8]; // :74:23
+static const uint32_t rc_duration_non_ht[8]; // :85:23
+
+static uint8_t rc_get_nss(uint16_t rate_config); // :164:16
+static uint8_t rc_get_mcs_index(uint16_t rate_config); // :198:16
+static void rc_calc_prob_ewma(struct rc_rate_stats *rc_rs); // :260:13
+static uint16_t rc_set_previous_mcs_index(struct rc_sta_stats *rc_ss, uint16_t rate_config); // :305:17
+static uint16_t rc_set_next_mcs_index(struct rc_sta_stats *rc_ss, uint16_t rate_config); // :364:17
+static uint16_t rc_new_random_rate(struct rc_sta_stats *rc_ss); // :580:17
+static bool is_cck_group(uint16_t rate_config); // :726:12
+static void rc_sort_samples_tp(struct rc_sta_stats *rc_ss, uint32_t *cur_tp); // :1031:13
+static bool rc_update_stats(struct rc_sta_stats *rc_ss, bool init); // :1072:12
+static void rc_update_retry_chain(struct rc_sta_stats *rc_ss, uint32_t *cur_tp); // :1173:13
+static bool rc_check_valid_rate(struct rc_sta_stats *rc_ss, uint16_t rate_config); // :1272:12
+static uint16_t rc_get_lowest_rate_config(struct rc_sta_stats *rc_ss); // :1520:17
+static uint16_t rc_get_initial_rate_config(struct rc_sta_stats *rc_ss); // :1582:17
+void rc_update_counters(uint8_t sta_idx, uint32_t attempts, uint32_t failures, bool tx_ampdu, bool retry_required); // :1989:6
+void rc_check(uint8_t sta_idx, bool *tx_ampdu); // :2079:6
+void rc_init(struct sta_info_tag *sta_entry); // :2136:6
+uint32_t rc_get_duration(uint16_t rate_config); // :2358:10
+void rc_update_bw_nss_max(uint8_t sta_idx, uint8_t bw_max, uint8_t nss_max); // :2402:6
+void rc_update_preamble_type(uint8_t sta_idx, uint8_t preamble_type); // :2471:6
+void rc_init_bcmc_rate(struct sta_info_tag *sta_entry, uint8_t basic_rate_idx); // :2533:6
+bool rc_check_fixed_rate_config(struct rc_sta_stats *rc_ss, uint16_t fixed_rate_config); // :2550:5
+uint32_t rc_calc_tp(struct rc_sta_stats *rc_ss, uint8_t sample_idx); // :2610:10
+
+/* ======== components/bl602/bl602_wifi/ip/umac/src/rc/rc.h ======== */
+
+struct rc_rate_stats {
+    uint16_t attempts;
+    uint16_t success;
+    uint16_t probability;
+    uint16_t rate_config;
+    uint8_t sample_skipped;
+    bool old_prob_available;
+    uint8_t n_retry;
+    bool rate_allowed;
+}; // :133:8
+
+struct step {
+    uint32_t tp;
+    uint16_t idx;
+}; // :154:8
+
+struct rc_sta_stats {
+    uint32_t last_rc_time;
+    struct rc_rate_stats rate_stats[10];
+    struct step retry[4];
+    struct step max_tp_2_trial;
+    uint16_t ampdu_len;
+    uint16_t ampdu_packets;
+    uint32_t avg_ampdu_len;
+    uint8_t sample_wait;
+    uint8_t sample_slow;
+    uint8_t trial_status;
+    uint8_t info;
+    uint8_t sw_retry_step;
+    uint8_t format_mod;
+    union {
+        uint8_t ht[4];
+    } rate_map;
+    uint16_t rate_map_l;
+    uint8_t mcs_max;
+    uint8_t r_idx_min;
+    uint8_t r_idx_max;
+    uint8_t bw_max;
+    uint8_t no_ss;
+    uint8_t short_gi;
+    uint8_t p_type;
+    uint16_t no_samples;
+    uint16_t max_amsdu_len;
+    uint16_t curr_amsdu_len;
+    uint16_t fixed_rate_cfg;
+}; // :163:8
+
+/* ======== components/bl602/bl602_wifi/ip/umac/src/rxu/rxu_cntrl.c ======== */
+
+struct rxu_cntrl_env_tag rxu_cntrl_env; // :134:26
+static const struct llc_snap_short rxu_cntrl_rfc1042_hdr; // :137:36
+static const struct llc_snap_short rxu_cntrl_bridge_tunnel_hdr; // :144:36
+
+static uint8_t rxu_cntrl_machdr_len_get(uint16_t frame_cntl); // :211:23
+static bool rxu_cntrl_protected_handle(uint8_t *frame, uint32_t statinfo); // :248:12
+
+uint32_t mac_payload_offset; // :375:10
+
+static bool rxu_mgt_frame_check(struct rx_swdesc *swdesc, uint8_t sta_idx); // :1705:12
+
+cm_ConnectionInfo_t sta_conn_info; // :1756:21
+cm_ConnectionInfo_t *uap_conn_info; // :1757:22
+
+void rxu_cntrl_init(void); // :1806:6
+bool rxu_cntrl_frame_handle(struct rx_swdesc *swdesc); // :1817:5
+void rxu_cntrl_monitor_pm(struct mac_addr *addr); // :1998:6
+uint8_t rxu_cntrl_get_pm(void); // :2012:9
+void rxu_cntrl_evt(int dummy); // :2024:6
+
+struct wifi_pkt {
+    uint32_t pkt[4];
+    void *pbuf[4];
+    uint16_t len[4];
+}; // :2039:8
+
+void rxu_swdesc_upload_evt(int arg); // :2047:6
+
+/* ======== components/bl602/bl602_wifi/ip/umac/src/rxu/rxu_cntrl.h ======== */
+
+enum rx_status_bits {
+    RX_STAT_FORWARD = 1,
+    RX_STAT_ALLOC = 2,
+    RX_STAT_DELETE = 4,
+    RX_STAT_LEN_UPDATE = 8,
+    RX_STAT_ETH_LEN_UPDATE = 16,
+    RX_STAT_COPY = 32,
+}; // :64:6
+
+enum rxu_cntrl_frame_info_pos {
+    RXU_CNTRL_MIC_CHECK_NEEDED = 1,
+    RXU_CNTRL_PN_CHECK_NEEDED = 2,
+    RXU_CNTRL_NEW_MESH_PEER = 4,
+}; // :106:6
+
+struct rxu_mic_calc {
+    struct mic_calc mic_calc;
+    uint32_t last_bytes[2];
+}; // :127:8
+
+struct rx_cntrl_rx_status {
+    uint16_t frame_cntl;
+    uint16_t seq_cntl;
+    uint16_t sn;
+    uint8_t fn;
+    uint8_t tid;
+    uint8_t machdr_len;
+    uint8_t sta_idx;
+    uint8_t vif_idx;
+    uint8_t dst_idx;
+    uint64_t pn;
+    uint32_t statinfo;
+    uint32_t host_buf_addr;
+    struct key_info_tag *key;
+    struct mac_addr da;
+    struct mac_addr sa;
+    uint8_t frame_info;
+    bool eth_len_present;
+    uint8_t payl_offset;
+}; // :213:8
+
+struct rx_cntrl_ipcdesc {
+    uint32_t host_id;
+}; // :262:8
+
+struct rx_cntrl_dupli {
+    struct mac_addr last_src_addr;
+    uint16_t last_seq_cntl;
+}; // :269:8
+
+struct rx_cntrl_pm_mon {
+    struct mac_addr addr;
+    uint8_t pm_state;
+    bool mon;
+}; // :278:8
+
+struct rxu_cntrl_env_tag {
+    struct rx_cntrl_rx_status rx_status;
+    struct co_list rxdesc_pending;
+    struct co_list rxdesc_ready;
+    struct rx_cntrl_ipcdesc rx_ipcdesc_stat;
+    struct co_list rxu_defrag_free;
+    struct co_list rxu_defrag_used;
+    struct rx_cntrl_dupli rxu_dupli;
+    struct mac_addr *mac_addr_ptr;
+    struct rx_cntrl_pm_mon pm_mon;
+    uint32_t ttr;
+}; // :290:8
+
+struct rxu_cntrl_env_tag rxu_cntrl_env; // :322:33
+
+/* ======== components/bl602/bl602_wifi/ip/umac/src/rxu/rxu_task.h ======== */
+
+enum rxu_msg_tag {
+    RXU_MGT_IND = 11264,
+    RXU_NULL_DATA = 11265,
+}; // :27:6
+
+struct rxu_mgt_ind {
+    uint16_t length;
+    uint16_t framectrl;
+    uint16_t center_freq;
+    uint8_t band;
+    uint8_t sta_idx;
+    uint8_t inst_nbr;
+    uint8_t sa[6];
+    uint32_t tsflo;
+    uint32_t tsfhi;
+    int8_t rssi;
+    int8_t ppm_abs;
+    int8_t ppm_rel;
+    uint8_t data_rate;
+    uint32_t payload[0];
+}; // :45:8
+
+/* ======== components/bl602/bl602_wifi/ip/umac/src/scanu/scanu.c ======== */
+
+struct scanu_env_tag scanu_env; // :61:22
+
+static void scanu_dma_cb(void *env, int dma_type); // :187:13
+void scanu_confirm(uint8_t status); // :225:6
+void scanu_raw_send_cfm(uint8_t status, ke_task_id_t dst_id); // :255:6
+void scanu_init(void); // :268:6
+int scanu_frame_handler(const struct rxu_mgt_ind *frame); // :288:5
+struct mac_scan_result *scanu_find_result(const struct mac_addr *bssid_ptr, bool allocate); // :673:25
+struct mac_scan_result *scanu_search_by_bssid(const struct mac_addr *bssid); // :704:25
+struct mac_scan_result *scanu_search_by_ssid(const struct mac_ssid *ssid, int *idx); // :709:25
+void scanu_rm_exist_ssid(const struct mac_ssid *ssid, int index); // :746:6
+void scanu_start(void); // :765:6
+void scanu_scan_next(void); // :801:6
+
+/* ======== components/bl602/bl602_wifi/ip/umac/src/scanu/scanu.h ======== */
+
+struct scanu_env_tag {
+    const struct scanu_start_req *param;
+    struct hal_dma_desc_tag dma_desc;
+    uint16_t result_cnt;
+    struct mac_scan_result scan_result[6];
+    ke_task_id_t src_id;
+    bool joining;
+    uint8_t band;
+    struct mac_addr bssid;
+    struct mac_ssid ssid;
+}; // :42:8
+
+struct scanu_add_ie_tag {
+    struct dma_desc dma_desc;
+    uint32_t buf[50];
+}; // :69:8
+
+struct scanu_env_tag scanu_env; // :81:29
+struct scanu_add_ie_tag scanu_add_ie; // :84:32
+
+/* ======== components/bl602/bl602_wifi/ip/umac/src/scanu/scanu_shared.c ======== */
+
+struct scanu_add_ie_tag scanu_add_ie; // :30:25
+
+/* ======== components/bl602/bl602_wifi/ip/umac/src/scanu/scanu_task.c ======== */
+
+static int scanu_start_req_handler(const ke_msg_id_t msgid, const struct scanu_start_req *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :50:1
+static void cfm_raw_send(void *env, uint32_t status); // :68:13
+static int scanu_raw_send_req_handler(const ke_msg_id_t msgid, const struct scanu_raw_send_req *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :130:1
+static int scanu_join_req_handler(const ke_msg_id_t msgid, const struct scanu_start_req *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :163:1
+static int scan_start_cfm_handler(const ke_msg_id_t msgid, const struct scan_start_cfm *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :203:1
+static int scan_done_ind_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :229:1
+static int rxu_mgt_ind_handler(const ke_msg_id_t msgid, const struct rxu_mgt_ind *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :256:1
+
+const struct ke_msg_handler scanu_idle[3]; // :270:29
+const struct ke_msg_handler scanu_scanning[3]; // :278:29
+const struct ke_msg_handler scanu_default_state[3]; // :286:29
+const struct ke_state_handler scanu_state_handler[2]; // :297:31
+const struct ke_state_handler scanu_default_handler; // :307:31
+ke_state_t scanu_state[1]; // :312:12
+
+/* ======== components/bl602/bl602_wifi/ip/umac/src/scanu/scanu_task.h ======== */
+
+struct scanu_start_req {
+    struct scan_chan_tag chan[42];
+    struct mac_ssid ssid[2];
+    struct mac_addr bssid;
+    uint32_t add_ies;
+    uint16_t add_ie_len;
+    uint8_t vif_idx;
+    uint8_t chan_cnt;
+    uint8_t ssid_cnt;
+    bool no_cck;
+}; // :62:8
+
+struct scanu_raw_send_req {
+    void *pkt;
+    uint32_t len;
+}; // :85:8
+
+struct scanu_raw_send_cfm {
+    uint32_t status;
+}; // :91:8
+
+struct scanu_start_cfm {
+    uint8_t status;
+}; // :97:8
+
+const struct ke_state_handler scanu_state_handler[2]; // :103:38
+const struct ke_state_handler scanu_default_handler; // :105:38
+ke_state_t scanu_state[1]; // :107:19
+
+/* ======== components/bl602/bl602_wifi/ip/umac/src/sm/sm.c ======== */
+
+struct sm_env_tag sm_env; // :50:19
+
+static void sm_frame_tx_cfm_handler(void *env, uint32_t status); // :64:13
+static void sm_deauth_cfm(void *env, uint32_t status); // :125:13
+static void sm_delete_resources(struct vif_info_tag *vif); // :137:13
+void sm_init(void); // :188:6
+void sm_get_bss_params(const struct mac_addr **bssid, const struct scan_chan_tag **chan); // :198:6
+void sm_scan_bss(const struct mac_addr *bssid, const struct scan_chan_tag *chan); // :239:6
+void sm_join_bss(const struct mac_addr *bssid, const struct scan_chan_tag *chan, bool passive); // :279:6
+uint8_t sm_add_chan_ctx(uint8_t *p_chan_idx); // :312:9
+void sm_set_bss_param(void); // :335:6
+void sm_send_next_bss_param(void); // :411:6
+void sm_disconnect(uint8_t vif_index, uint16_t reason_code); // :422:6
+void sm_disconnect_process(struct vif_info_tag *vif, uint16_t reason); // :527:6
+void sm_connect_ind(uint16_t status); // :546:6
+void sm_auth_send(uint16_t auth_seq, uint32_t *challenge); // :618:6
+void sm_assoc_req_send(void); // :724:6
+void sm_assoc_done(uint16_t aid); // :819:6
+void sm_auth_handler(const struct rxu_mgt_ind *param); // :840:6
+void sm_assoc_rsp_handler(const struct rxu_mgt_ind *param); // :939:6
+int sm_deauth_handler(const struct rxu_mgt_ind *param); // :1009:5
+static void sm_supplicant_deauth_cfm(void *env, uint32_t status); // :1145:13
+void sm_handle_supplicant_result(uint8_t sta_id, uint16_t reason_code); // :1153:6
+
+/* ======== components/bl602/bl602_wifi/ip/umac/src/sm/sm.h ======== */
+
+struct sm_env_tag {
+    struct sm_connect_req *connect_param;
+    struct sm_connect_ind *connect_ind;
+    struct co_list bss_config;
+    bool join_passive;
+    bool ft_over_ds;
+    int exist_ssid_idx;
+    struct mac_addr ft_old_bssid;
+}; // :36:8
+
+struct sm_env_tag sm_env; // :239:26
+
+/* ======== components/bl602/bl602_wifi/ip/umac/src/sm/sm_task.c ======== */
+
+static int sm_connect_req_handler(const ke_msg_id_t msgid, const struct sm_connect_req *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :50:1
+static int sm_disconnect_req_handler(const ke_msg_id_t msgid, const struct sm_disconnect_req *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :162:1
+static int mm_connection_loss_ind_handler(const ke_msg_id_t msgid, const struct mm_connection_loss_ind *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :191:1
+static int sm_rsp_timeout_ind_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :228:1
+static int scanu_start_cfm_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :257:1
+static int scanu_join_cfm_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :297:1
+static int mm_sta_add_cfm_handler(const ke_msg_id_t msgid, const struct mm_sta_add_cfm *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :406:1
+static int me_set_ps_disable_cfm_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :467:1
+static int mm_bss_param_setting_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :500:1
+static int me_set_active_cfm_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :527:1
+static int mm_set_vif_state_cfm_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :582:1
+static int rxu_mgt_ind_handler(const ke_msg_id_t msgid, const struct rxu_mgt_ind *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :651:1
+
+const struct ke_msg_handler sm_default_state[17]; // :691:29
+const struct ke_state_handler sm_default_handler; // :713:31
+ke_state_t sm_state[1]; // :717:12
+
+/* ======== components/bl602/bl602_wifi/ip/umac/src/sm/sm_task.h ======== */
+
+enum sm_state_tag {
+    SM_IDLE = 0,
+    SM_SCANNING = 1,
+    SM_JOINING = 2,
+    SM_STA_ADDING = 3,
+    SM_BSS_PARAM_SETTING = 4,
+    SM_AUTHENTICATING = 5,
+    SM_ASSOCIATING = 6,
+    SM_ACTIVATING = 7,
+    SM_DISCONNECTING = 8,
+    SM_STATE_MAX = 9,
+}; // :32:6
+
+enum sm_msg_tag {
+    SM_CONNECT_REQ = 6144,
+    SM_CONNECT_CFM = 6145,
+    SM_CONNECT_IND = 6146,
+    SM_DISCONNECT_REQ = 6147,
+    SM_DISCONNECT_CFM = 6148,
+    SM_DISCONNECT_IND = 6149,
+    SM_RSP_TIMEOUT_IND = 6150,
+}; // :57:6
+
+struct sm_connect_req {
+    struct mac_ssid ssid;
+    struct mac_addr bssid;
+    struct scan_chan_tag chan;
+    uint32_t flags;
+    uint16_t ctrl_port_ethertype;
+    uint16_t ie_len;
+    uint16_t listen_interval;
+    bool dont_wait_bcmc;
+    uint8_t auth_type;
+    uint8_t uapsd_queues;
+    uint8_t vif_idx;
+    uint32_t ie_buf[64];
+    bool is_supplicant_enabled;
+    uint8_t phrase[64];
+    uint8_t phrase_pmk[64];
+}; // :76:8
+
+struct sm_connect_cfm {
+    uint8_t status;
+}; // :113:8
+
+struct sm_connect_ind {
+    uint16_t status_code;
+    struct mac_addr bssid;
+    bool roamed;
+    uint8_t vif_idx;
+    uint8_t ap_idx;
+    uint8_t ch_idx;
+    bool qos;
+    uint8_t acm;
+    uint16_t assoc_req_ie_len;
+    uint16_t assoc_rsp_ie_len;
+    uint32_t assoc_ie_buf[200];
+    uint16_t aid;
+    uint8_t band;
+    uint16_t center_freq;
+    uint8_t width;
+    uint32_t center_freq1;
+    uint32_t center_freq2;
+    uint32_t ac_param[4];
+}; // :126:8
+
+struct sm_disconnect_req {
+    uint16_t reason_code;
+    uint8_t vif_idx;
+}; // :167:8
+
+struct sm_disconnect_ind {
+    uint16_t reason_code;
+    uint8_t vif_idx;
+    bool ft_over_ds;
+}; // :176:8
+
+const struct ke_state_handler sm_default_handler; // :188:38
+ke_state_t sm_state[1]; // :191:19
+
+/* ======== components/bl602/bl602_wifi/ip/umac/src/txu/txu_cntrl.c ======== */
+
+void txu_cntrl_init(void); // :765:6
+void txu_cntrl_frame_build(struct txdesc *txdesc, uint32_t buf); // :769:6
+bool txu_cntrl_push(struct txdesc *txdesc, uint8_t access_category); // :790:5
+void txu_cntrl_tkip_mic_append(struct txdesc *txdesc, uint8_t ac); // :849:6
+void txu_cntrl_cfm(struct txdesc *txdesc); // :909:6
+void txu_cntrl_protect_mgmt_frame(struct txdesc *txdesc, uint32_t frame, uint16_t hdr_len); // :980:6
+
+/* ======== components/bl602/bl602_wifi/modules/common/src/co_dlist.c ======== */
+
+void co_dlist_init(struct co_dlist *list); // :33:6
+void co_dlist_push_back(struct co_dlist *list, struct co_dlist_hdr *list_hdr); // :45:6
+void co_dlist_push_front(struct co_dlist *list, struct co_dlist_hdr *list_hdr); // :74:6
+struct co_dlist_hdr *co_dlist_pop_front(struct co_dlist *list); // :102:22
+void co_dlist_extract(struct co_dlist *list, const struct co_dlist_hdr *list_hdr); // :134:6
+
+/* ======== components/bl602/bl602_wifi/modules/common/src/co_dlist.h ======== */
+
+struct co_dlist_hdr {
+    struct co_dlist_hdr *next;
+    struct co_dlist_hdr *prev;
+}; // :48:8
+
+struct co_dlist {
+    struct co_dlist_hdr *first;
+    struct co_dlist_hdr *last;
+    uint32_t cnt;
+}; // :57:8
+
+/* ======== components/bl602/bl602_wifi/modules/common/src/co_list.c ======== */
+
+void co_list_init(struct co_list *list); // :36:6
+void co_list_pool_init(struct co_list *list, void *pool, size_t elmt_size, uint32_t elmt_cnt, void *default_value); // :42:6
+void co_list_push_back(struct co_list *list, struct co_list_hdr *list_hdr); // :67:6
+void co_list_push_front(struct co_list *list, struct co_list_hdr *list_hdr); // :90:6
+struct co_list_hdr *co_list_pop_front(struct co_list *list); // :108:21
+void co_list_extract(struct co_list *list, struct co_list_hdr *list_hdr); // :123:6
+bool co_list_find(struct co_list *list, struct co_list_hdr *list_hdr); // :166:5
+uint32_t co_list_cnt(const struct co_list *const list); // :181:10
+void co_list_insert(struct co_list *const list, struct co_list_hdr *const element, bool (*cmp)(const struct co_list_hdr *, const struct co_list_hdr *)); // :211:6
+void co_list_insert_after(struct co_list *const list, struct co_list_hdr *const prev_element, struct co_list_hdr *const element); // :254:6
+void co_list_insert_before(struct co_list *const list, struct co_list_hdr *const next_element, struct co_list_hdr *const element); // :293:6
+void co_list_concat(struct co_list *list1, struct co_list *list2); // :332:6
+void co_list_remove(struct co_list *list, struct co_list_hdr *prev_element, struct co_list_hdr *element); // :355:6
+
+/* ======== components/bl602/bl602_wifi/modules/common/src/co_list.h ======== */
+
+struct co_list_hdr {
+    struct co_list_hdr *next;
+}; // :47:8
+
+struct co_list {
+    struct co_list_hdr *first;
+    struct co_list_hdr *last;
+}; // :54:8
+
+/* ======== components/bl602/bl602_wifi/modules/common/src/co_math.c ======== */
+
+static const uint32_t crc_tab[256]; // :32:23
+
+uint32_t co_crc32(uint32_t addr, uint32_t len, uint32_t crc); // :105:10
+
+/* ======== components/bl602/bl602_wifi/modules/common/src/co_math.h ======== */
+
+static unsigned long next; // :107:26
+
+/* ======== components/bl602/bl602_wifi/modules/common/src/co_pool.c ======== */
+
+void co_pool_init(struct co_pool *pool, struct co_pool_hdr *pool_hdr, void *elements, uint32_t elem_size, uint32_t elem_cnt); // :33:6
+struct co_pool_hdr *co_pool_alloc(struct co_pool *pool, uint32_t nbelem); // :66:21
+void co_pool_free(struct co_pool *pool, struct co_pool_hdr *elements, uint32_t nbelem); // :105:6
+
+/* ======== components/bl602/bl602_wifi/modules/common/src/co_pool.h ======== */
+
+struct co_pool_hdr {
+    struct co_pool_hdr *next;
+    void *element;
+}; // :53:8
+
+struct co_pool {
+    struct co_pool_hdr *first_ptr;
+    uint32_t freecnt;
+}; // :64:8
+
+/* ======== components/bl602/bl602_wifi/modules/common/src/notifier.c ======== */
+
+int notifier_chain_regsiter(struct notifier_block **list, struct notifier_block *n); // :6:5
+int notifier_chain_regsiter_fromCritical(struct notifier_block **list, struct notifier_block *n); // :22:5
+int notifier_chain_unregsiter(struct notifier_block **list, struct notifier_block *n); // :37:5
+int notifier_chain_unregsiter_fromCritical(struct notifier_block **list, struct notifier_block *n); // :53:5
+int notifier_chain_call(struct notifier_block **list, int event, void *env); // :65:5
+int notifier_chain_call_fromeCritical(struct notifier_block **list, int event, void *env); // :81:5
+
+/* ======== components/bl602/bl602_wifi/modules/common/src/notifier.h ======== */
+
+struct notifier_block {
+    int (*cb)(struct notifier_block *, int, void *);
+    struct notifier_block *next;
+    int priority;
+}; // :3:8
+
+/* ======== components/bl602/bl602_wifi/modules/dbg/src/dbg.c ======== */
+
+struct debug_env_tag dbg_env; // :40:22
+
+void dbg_init(void); // :299:6
+
+/* ======== components/bl602/bl602_wifi/modules/dbg/src/dbg.h ======== */
+
+enum dbg_mod_tag {
+    DBG_MOD_IDX_KE = 0,
+    DBG_MOD_IDX_DBG = 1,
+    DBG_MOD_IDX_IPC = 2,
+    DBG_MOD_IDX_DMA = 3,
+    DBG_MOD_IDX_MM = 4,
+    DBG_MOD_IDX_TX = 5,
+    DBG_MOD_IDX_RX = 6,
+    DBG_MOD_IDX_PHY = 7,
+    DBG_MOD_IDX_MAX = 8,
+}; // :88:6
+
+enum dbg_sev_tag {
+    DBG_SEV_IDX_NONE = 0,
+    DBG_SEV_IDX_CRT = 1,
+    DBG_SEV_IDX_ERR = 2,
+    DBG_SEV_IDX_WRN = 3,
+    DBG_SEV_IDX_INF = 4,
+    DBG_SEV_IDX_VRB = 5,
+    DBG_SEV_IDX_MAX = 6,
+    DBG_SEV_ALL = 7,
+}; // :108:6
+
+struct debug_env_tag {
+    uint32_t filter_module;
+    uint32_t filter_severity;
+}; // :1287:8
+
+struct debug_env_tag dbg_env; // :1300:29
+
+/* ======== components/bl602/bl602_wifi/modules/dbg/src/dbg_print.c ======== */
+
+static const uint8_t transition_table[8]; // :83:22
+static const char hex_upper_table[17]; // :97:19
+
+void dbg_test_print(const char *fmt); // :638:6
+uint32_t dbg_snprintf(char *buffer, uint32_t size, const char *fmt); // :705:10
+
+/* ======== components/bl602/bl602_wifi/modules/dbg/src/dbg_task.c ======== */
+
+static int dbg_mem_read_req_handler(const ke_msg_id_t msgid, const struct dbg_mem_read_req *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :53:1
+static int dbg_mem_write_req_handler(const ke_msg_id_t msgid, const struct dbg_mem_write_req *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :88:1
+static int dbg_set_mod_filter_req_handler(const ke_msg_id_t msgid, const struct dbg_set_mod_filter_req *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :125:1
+static int dbg_set_sev_filter_req_handler(const ke_msg_id_t msgid, const struct dbg_set_sev_filter_req *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :155:1
+static int dbg_get_sys_stat_req_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :185:1
+
+const struct ke_msg_handler dbg_default_state[5]; // :245:29
+const struct ke_state_handler dbg_default_handler; // :264:31
+
+/* ======== components/bl602/bl602_wifi/modules/dbg/src/dbg_task.h ======== */
+
+enum dbg_msg_tag {
+    DBG_MEM_READ_REQ = 1024,
+    DBG_MEM_READ_CFM = 1025,
+    DBG_MEM_WRITE_REQ = 1026,
+    DBG_MEM_WRITE_CFM = 1027,
+    DBG_SET_MOD_FILTER_REQ = 1028,
+    DBG_SET_MOD_FILTER_CFM = 1029,
+    DBG_SET_SEV_FILTER_REQ = 1030,
+    DBG_SET_SEV_FILTER_CFM = 1031,
+    DBG_ERROR_IND = 1032,
+    DBG_GET_SYS_STAT_REQ = 1033,
+    DBG_GET_SYS_STAT_CFM = 1034,
+    DBG_SYS_STAT_TIMER = 1035,
+}; // :41:6
+
+struct dbg_mem_read_req {
+    uint32_t memaddr;
+}; // :76:8
+
+struct dbg_mem_read_cfm {
+    uint32_t memaddr;
+    uint32_t memdata;
+}; // :83:8
+
+struct dbg_mem_write_req {
+    uint32_t memaddr;
+    uint32_t memdata;
+}; // :92:8
+
+struct dbg_mem_write_cfm {
+    uint32_t memaddr;
+    uint32_t memdata;
+}; // :101:8
+
+struct dbg_set_mod_filter_req {
+    uint32_t mod_filter;
+}; // :110:8
+
+struct dbg_set_sev_filter_req {
+    uint32_t sev_filter;
+}; // :117:8
+
+struct dbg_get_sys_stat_cfm {
+    uint32_t cpu_sleep_time;
+    uint32_t doze_time;
+    uint32_t stats_time;
+}; // :124:8
+
+const struct ke_state_handler dbg_default_handler; // :138:38
+
+/* ======== components/bl602/bl602_wifi/modules/ke/src/ke_env.c ======== */
+
+struct ke_env_tag ke_env; // :26:19
+
+/* ======== components/bl602/bl602_wifi/modules/ke/src/ke_env.h ======== */
+
+typedef uint32_t evt_field_t; // :43:18
+
+struct ke_env_tag {
+    volatile evt_field_t evt_field;
+    struct co_list queue_sent;
+    struct co_list queue_saved;
+    struct co_list queue_timer;
+    struct mblock_free *mblock_first;
+}; // :46:8
+
+struct ke_env_tag ke_env; // :70:26
+
+/* ======== components/bl602/bl602_wifi/modules/ke/src/ke_event.c ======== */
+
+typedef void (*evt_ptr_t)(int); // :43:16
+
+struct ke_evt_tag {
+    evt_ptr_t func;
+    int param;
+}; // :47:8
+
+void bl_event_handle(int param); // :73:6
+
+static const struct ke_evt_tag ke_evt_hdlr[32]; // :81:32
+
+void bl60x_fw_dump_statistic(int forced); // :128:6
+void bl_fw_statistic_dump(int param); // :137:6
+void ke_evt_set(const evt_field_t event); // :176:6
+void ke_evt_clear(const evt_field_t event); // :193:6
+void ke_evt_schedule(void); // :210:6
+void ke_init(void); // :240:6
+void ke_flush(void); // :270:6
+
+/* ======== components/bl602/bl602_wifi/modules/ke/src/ke_mem.c ======== */
+
+struct mblock_free {
+    struct mblock_free *next;
+    uint32_t size;
+}; // :45:8
+
+struct mblock_used {
+    uint32_t size;
+}; // :56:8
+
+uint8_t ke_mem_heap[5248]; // :69:9
+
+struct mblock_free *ke_mem_init(void); // :76:21
+void *ke_malloc(uint32_t size); // :104:7
+void ke_free(void *mem_ptr); // :181:6
+
+/* ======== components/bl602/bl602_wifi/modules/ke/src/ke_msg.c ======== */
+
+void *ke_msg_alloc(const ke_msg_id_t id, const ke_task_id_t dest_id, const ke_task_id_t src_id, const uint16_t param_len); // :71:7
+void ke_msg_send(const void *param_ptr); // :111:6
+void ke_msg_send_basic(const ke_msg_id_t id, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :146:6
+void ke_msg_forward(const void *param_ptr, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :166:6
+void ke_msg_forward_and_change_id(const void *param_ptr, const ke_msg_id_t msg_id, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :195:6
+void ke_msg_free(const struct ke_msg *msg); // :219:6
+
+/* ======== components/bl602/bl602_wifi/modules/ke/src/ke_msg.h ======== */
+
+typedef uint16_t ke_task_id_t; // :63:18
+typedef uint16_t ke_state_t; // :75:18
+typedef uint16_t ke_msg_id_t; // :81:18
+
+struct ke_msg {
+    struct co_list_hdr hdr;
+    ke_msg_id_t id;
+    ke_task_id_t dest_id;
+    ke_task_id_t src_id;
+    uint16_t param_len;
+    uint32_t param[0];
+}; // :84:8
+
+enum ke_msg_status_tag {
+    KE_MSG_CONSUMED = 0,
+    KE_MSG_NO_FREE = 1,
+    KE_MSG_SAVED = 2,
+}; // :97:6
+
+/* ======== components/bl602/bl602_wifi/modules/ke/src/ke_queue.c ======== */
+
+struct co_list_hdr *ke_queue_extract(struct co_list *const queue, bool (*func)(const struct co_list_hdr *, uint32_t), uint32_t arg); // :43:21
+
+/* ======== components/bl602/bl602_wifi/modules/ke/src/ke_task.c ======== */
+
+static const struct ke_task_desc TASK_DESC[14]; // :65:34
+
+static bool cmp_dest_id(const struct co_list_hdr *msg, uint32_t dest_id); // :113:12
+void ke_state_set(const ke_task_id_t id, const ke_state_t state_id); // :170:6
+ke_state_t ke_state_get(const ke_task_id_t id); // :210:12
+static ke_msg_func_t ke_handler_search(const ke_msg_id_t msg_id, const struct ke_state_handler *state_handler); // :235:22
+void ke_task_schedule(int dummy); // :309:6
+int ke_msg_discard(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :387:5
+int ke_msg_save(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :406:5
+
+/* ======== components/bl602/bl602_wifi/modules/ke/src/ke_task.h ======== */
+
+typedef int (*ke_msg_func_t)(const ke_msg_id_t, const void *, const ke_task_id_t, const ke_task_id_t); // :120:15
+
+struct ke_msg_handler {
+    ke_msg_id_t id;
+    ke_msg_func_t func;
+}; // :126:8
+
+struct ke_state_handler {
+    const struct ke_msg_handler *msg_table;
+    uint16_t msg_cnt;
+}; // :135:8
+
+struct ke_task_desc {
+    const struct ke_state_handler *state_handler;
+    const struct ke_state_handler *default_handler;
+    ke_state_t *state;
+    uint16_t state_max;
+    uint16_t idx_max;
+}; // :151:8
+
+static bool ke_task_local(const ke_task_id_t id); // :179:21
+
+/* ======== components/bl602/bl602_wifi/modules/ke/src/ke_timer.c ======== */
+
+static void ke_timer_hw_set(struct ke_timer *timer); // :46:13
+static bool cmp_abs_time(const struct co_list_hdr *timerA, const struct co_list_hdr *timerB); // :84:12
+static bool cmp_timer_id(const struct co_list_hdr *timer, uint32_t timer_task); // :102:12
+void ke_timer_set(const ke_msg_id_t timer_id, const ke_task_id_t task_id, const uint32_t delay); // :133:6
+void ke_timer_clear(const ke_msg_id_t timer_id, const ke_task_id_t task_id); // :197:6
+void ke_timer_schedule(int dummy); // :246:6
+bool ke_timer_active(const ke_msg_id_t timer_id, const ke_task_id_t task_id); // :302:5
+
+/* ======== components/bl602/bl602_wifi/modules/ke/src/ke_timer.h ======== */
+
+struct ke_timer {
+    struct ke_timer *next;
+    ke_msg_id_t id;
+    ke_task_id_t task;
+    uint32_t time;
+}; // :62:8
+
+/* ======== components/bl602/bl602_wifi/modules/mac/src/mac.c ======== */
+
+const uint8_t mac_tid2ac[]; // :31:15
+const uint8_t mac_ac2uapsd[4]; // :44:15
+const uint8_t mac_id2rate[]; // :53:15
+const struct mac_addr mac_addr_bcst; // :92:23
+
+uint32_t mac_paid_gid_sta_compute(const struct mac_addr *p_mac_addr); // :99:10
+uint32_t mac_paid_gid_ap_compute(const struct mac_addr *p_mac_addr, uint16_t aid); // :110:10
+void bl60x_current_time_us(long long *time_now); // :123:6
+
+/* ======== components/bl602/bl602_wifi/modules/mac/src/mac.h ======== */
+
+struct mac_addr {
+    uint16_t array[3];
+}; // :207:8
+
+struct mac_ssid {
+    uint8_t length;
+    uint8_t array[32];
+    uint8_t array_tail[1];
+}; // :217:8
+
+struct mac_rateset {
+    uint8_t length;
+    uint8_t array[12];
+}; // :232:8
+
+struct key_info_tag {
+    uint64_t rx_pn[9];
+    uint64_t tx_pn;
+    union {
+        struct {
+            uint32_t tx_key[2];
+            uint32_t rx_key[2];
+        } mic;
+        struct {
+            uint32_t key[4];
+        } mfp;
+    } u;
+    uint8_t cipher;
+    uint8_t key_idx;
+    uint8_t hw_key_idx;
+    bool valid;
+}; // :257:8
+
+struct mac_sec_key {
+    uint8_t length;
+    uint32_t array[8];
+}; // :292:8
+
+struct mac_htcapability {
+    uint16_t ht_capa_info;
+    uint8_t a_mpdu_param;
+    uint8_t mcs_rate[16];
+    uint16_t ht_extended_capa;
+    uint32_t tx_beamforming_capa;
+    uint8_t asel_capa;
+}; // :303:8
+
+struct mac_vhtcapability {
+    uint32_t vht_capa_info;
+    uint16_t rx_mcs_map;
+    uint16_t rx_highest;
+    uint16_t tx_mcs_map;
+    uint16_t tx_highest;
+}; // :321:8
+
+struct mac_edca_param_set {
+    uint8_t qos_info;
+    uint8_t acm;
+    uint32_t ac_param[4];
+}; // :353:8
+
+struct mac_scan_result {
+    struct mac_addr bssid;
+    struct mac_ssid ssid;
+    uint16_t bsstype;
+    struct scan_chan_tag *chan;
+    uint16_t beacon_period;
+    uint16_t cap_info;
+    bool valid_flag;
+    int8_t rssi;
+    int8_t ppm_rel;
+    int8_t ppm_abs;
+}; // :381:8
+
+struct mac_sta_info {
+    struct mac_rateset rate_set;
+    struct mac_htcapability ht_cap;
+    struct mac_vhtcapability vht_cap;
+    uint32_t capa_flags;
+    uint8_t phy_bw_max;
+    uint8_t bw_cur;
+    uint8_t uapsd_queues;
+    uint8_t max_sp_len;
+    uint8_t stbc_nss;
+}; // :471:8
+
+const uint8_t mac_tid2ac[]; // :499:22
+const uint8_t mac_ac2uapsd[4]; // :502:22
+const uint8_t mac_id2rate[]; // :505:22
+const struct mac_addr mac_addr_bcst; // :512:30
+
+/* ======== components/bl602/bl602_wifi/modules/mac/src/mac_frame.h ======== */
+
+struct mac_hdr_ctrl {
+    uint16_t fctl;
+    uint16_t durid;
+    struct mac_addr addr1;
+    struct mac_addr addr2;
+}; // :1774:8
+
+struct mac_hdr {
+    uint16_t fctl;
+    uint16_t durid;
+    struct mac_addr addr1;
+    struct mac_addr addr2;
+    struct mac_addr addr3;
+    uint16_t seq;
+}; // :1787:8
+
+struct mac_hdr_qos {
+    uint16_t fctl;
+    uint16_t durid;
+    struct mac_addr addr1;
+    struct mac_addr addr2;
+    struct mac_addr addr3;
+    uint16_t seq;
+    uint16_t qos;
+}; // :1804:8
+
+struct mac_hdr_long {
+    uint16_t fctl;
+    uint16_t durid;
+    struct mac_addr addr1;
+    struct mac_addr addr2;
+    struct mac_addr addr3;
+    uint16_t seq;
+    struct mac_addr addr4;
+}; // :1823:8
+
+struct mac_hdr_long_qos {
+    uint16_t fctl;
+    uint16_t durid;
+    struct mac_addr addr1;
+    struct mac_addr addr2;
+    struct mac_addr addr3;
+    uint16_t seq;
+    struct mac_addr addr4;
+    uint16_t qos;
+}; // :1843:8
+
+struct eth_hdr {
+    struct mac_addr da;
+    struct mac_addr sa;
+    uint16_t len;
+}; // :1864:8
+
+struct bcn_frame {
+    struct mac_hdr h;
+    uint64_t tsf;
+    uint16_t bcnint;
+    uint16_t capa;
+    uint8_t variable[0];
+}; // :1875:8
+
+struct preq_frame {
+    struct mac_hdr h;
+    uint8_t payload[0];
+}; // :1890:8
+
+/* ======== components/bl602/bl602_wifi/modules/mac/src/mac_ie.c ======== */
+
+uint32_t mac_ie_find(uint32_t addr, uint16_t buflen, uint8_t ie_id); // :39:10
+uint32_t mac_vsie_find(uint32_t addr, uint16_t buflen, const uint8_t *oui, uint8_t ouilen); // :65:10
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/IEEE_types.h ======== */
+
+typedef enum {
+    IEEE_8021X_PACKET_TYPE_EAP_PACKET = 0,
+    IEEE_8021X_PACKET_TYPE_EAPOL_START = 1,
+    IEEE_8021X_PACKET_TYPE_EAPOL_LOGOFF = 2,
+    IEEE_8021X_PACKET_TYPE_EAPOL_KEY = 3,
+    IEEE_8021X_PACKET_TYPE_ASF_ALERT = 4,
+} IEEEtypes_8021x_PacketType_e; // :418:27
+
+typedef enum {
+    IEEE_8021X_CODE_TYPE_REQUEST = 1,
+    IEEE_8021X_CODE_TYPE_RESPONSE = 2,
+    IEEE_8021X_CODE_TYPE_SUCCESS = 3,
+    IEEE_8021X_CODE_TYPE_FAILURE = 4,
+} IEEEtypes_8021x_CodeType_e; // :428:27
+
+typedef enum {
+    ELEM_ID_SSID = 0,
+    ELEM_ID_SUPPORTED_RATES = 1,
+    ELEM_ID_FH_PARAM_SET = 2,
+    ELEM_ID_DS_PARAM_SET = 3,
+    ELEM_ID_CF_PARAM_SET = 4,
+    ELEM_ID_TIM = 5,
+    ELEM_ID_IBSS_PARAM_SET = 6,
+    ELEM_ID_COUNTRY = 7,
+    ELEM_ID_HOP_PARAM = 8,
+    ELEM_ID_HOP_TABLE = 9,
+    ELEM_ID_REQUEST = 10,
+    ELEM_ID_BSS_LOAD = 11,
+    ELEM_ID_EDCA_PARAM_SET = 12,
+    ELEM_ID_TSPEC = 13,
+    ELEM_ID_TCLAS = 14,
+    ELEM_ID_SCHEDULE = 15,
+    ELEM_ID_CHALLENGE_TEXT = 16,
+    ELEM_ID_POWER_CONSTRAINT = 32,
+    ELEM_ID_POWER_CAPABILITY = 33,
+    ELEM_ID_TPC_REQUEST = 34,
+    ELEM_ID_TPC_REPORT = 35,
+    ELEM_ID_SUPPORTED_CHANNELS = 36,
+    ELEM_ID_CHANNEL_SWITCH_ANN = 37,
+    ELEM_ID_MEASUREMENT_REQ = 38,
+    ELEM_ID_MEASUREMENT_RPT = 39,
+    ELEM_ID_QUIET = 40,
+    ELEM_ID_IBSS_DFS = 41,
+    ELEM_ID_ERP_INFO = 42,
+    ELEM_ID_TS_DELAY = 43,
+    ELEM_ID_TCLAS_PROCESS = 44,
+    ELEM_ID_HT_CAPABILITY = 45,
+    ELEM_ID_QOS_CAPABILITY = 46,
+    ELEM_ID_RSN = 48,
+    ELEM_ID_EXT_SUPPORTED_RATES = 50,
+    ELEM_ID_AP_CHANNEL_REPORT = 51,
+    ELEM_ID_NEIGHBOR_REPORT = 52,
+    ELEM_ID_RCPI = 53,
+    ELEM_ID_MOBILITY_DOMAIN = 54,
+    ELEM_ID_FAST_BSS_TRANS = 55,
+    ELEM_ID_TIMEOUT_INTERVAL = 56,
+    ELEM_ID_RIC_DATA = 57,
+    ELEM_ID_DSE_REGISTERED_LOC = 58,
+    ELEM_ID_SUPPORTED_REGCLASS = 59,
+    ELEM_ID_EXT_CHAN_SWITCH_ANN = 60,
+    ELEM_ID_HT_INFORMATION = 61,
+    ELEM_ID_SECONDARY_CHAN_OFFSET = 62,
+    ELEM_ID_BSS_ACCESS_DELAY = 63,
+    ELEM_ID_ANTENNA_INFO = 64,
+    ELEM_ID_RSNI = 65,
+    ELEM_ID_MEAS_PILOT_TX_INFO = 66,
+    ELEM_ID_BSS_AVAIL_ADM_CAP = 67,
+    ELEM_ID_BSS_AC_ACCESS_DELAY = 68,
+    ELEM_ID_RRM_ENABLED_CAP = 70,
+    ELEM_ID_MULTI_BSSID = 71,
+    ELEM_ID_2040_BSS_COEXISTENCE = 72,
+    ELEM_ID_2040_BSS_INTOL_CHRPT = 73,
+    ELEM_ID_OBSS_SCAN_PARAM = 74,
+    ELEM_ID_RIC_DESCRIPTOR = 75,
+    ELEM_ID_MANAGEMENT_MIC = 76,
+    ELEM_ID_EVENT_REQUEST = 78,
+    ELEM_ID_EVENT_REPORT = 79,
+    ELEM_ID_DIAG_REQUEST = 80,
+    ELEM_ID_DIAG_REPORT = 81,
+    ELEM_ID_LOCATION_PARAM = 82,
+    ELEM_ID_NONTRANS_BSSID_CAP = 83,
+    ELEM_ID_SSID_LIST = 84,
+    ELEM_ID_MBSSID_INDEX = 85,
+    ELEM_ID_FMS_DESCRIPTOR = 86,
+    ELEM_ID_FMS_REQUEST = 87,
+    ELEM_ID_FMS_RESPONSE = 88,
+    ELEM_ID_QOS_TRAFFIC_CAP = 89,
+    ELEM_ID_BSS_MAX_IDLE_PERIOD = 90,
+    ELEM_ID_TFS_REQUEST = 91,
+    ELEM_ID_TFS_RESPONSE = 92,
+    ELEM_ID_WNM_SLEEP_MODE = 93,
+    ELEM_ID_TIM_BCAST_REQUEST = 94,
+    ELEM_ID_TIM_BCAST_RESPONSE = 95,
+    ELEM_ID_COLLOC_INTF_REPORT = 96,
+    ELEM_ID_CHANNEL_USAGE = 97,
+    ELEM_ID_TIME_ZONE = 98,
+    ELEM_ID_DMS_REQUEST = 99,
+    ELEM_ID_DMS_RESPONSE = 100,
+    ELEM_ID_LINK_ID = 101,
+    ELEM_ID_WAKEUP_SCHEDULE = 102,
+    ELEM_ID_TDLS_CS_TIMING = 104,
+    ELEM_ID_PTI_CONTROL = 105,
+    ELEM_ID_PU_BUFFER_STATUS = 106,
+    ELEM_ID_EXT_CAPABILITIES = 127,
+    ELEM_ID_VHT_CAPABILITIES = 191,
+    ELEM_ID_VHT_OPERATION = 192,
+    ELEM_ID_WIDE_BAND_CHAN_SW = 193,
+    ELEM_ID_AID = 197,
+    ELEM_ID_VHT_OP_MODE_NOTIFICATION = 199,
+    ELEM_ID_VENDOR_SPECIFIC = 221,
+    ELEM_ID_EXTENSION = 255,
+    ELEM_ID_EXT_ASSOC_DELAY_INFO = 1,
+    ELEM_ID_EXT_FILS_REQ_PARAMS = 2,
+    ELEM_ID_EXT_FILS_KEY_CONFIRM = 3,
+    ELEM_ID_EXT_FILS_SESSION = 4,
+    ELEM_ID_EXT_FILS_HLP_CONTAINER = 5,
+    ELEM_ID_EXT_FILS_IP_ADDR_ASSIGN = 6,
+    ELEM_ID_EXT_KEY_DELIVERY = 7,
+    ELEM_ID_EXT_FILS_WRAPPED_DATA = 8,
+    ELEM_ID_EXT_FTM_SYNC_INFO = 9,
+    ELEM_ID_EXT_EXTENDED_REQUEST = 10,
+    ELEM_ID_EXT_ESTIMATED_SERVICE_PARAMS = 11,
+    ELEM_ID_EXT_FILS_PUBLIC_KEY = 12,
+    ELEM_ID_EXT_FILS_NONCE = 13,
+    ELEM_ID_EXT_FUTURE_CHANNEL_GUIDANCE = 14,
+    ELEM_ID_EXT_OWE_DH_PARAM = 32,
+    ELEM_ID_EXT_PASSWORD_IDENTIFIER = 33,
+    ELEM_ID_EXT_HE_CAPABILITIES = 35,
+    ELEM_ID_EXT_HE_OPERATION = 36,
+    SUBELEM_ID_REPORTED_FRAME_BODY = 1,
+    SUBELEM_ID_REPORTING_DETAIL = 2,
+    SUBELEM_ID_PMK_R1_KEY_HOLDER_ID = 1,
+    SUBELEM_ID_GTK = 2,
+    SUBELEM_ID_PMK_R0_KEY_HOLDER_ID = 3,
+    SUBELEM_ID_IGTK = 4,
+    ELEM_ID_WAPI = 68,
+} IEEEtypes_ElementId_e; // :761:3
+
+typedef enum {
+    KDE_DATA_TYPE_RESERVED = 0,
+    KDE_DATA_TYPE_GTK = 1,
+    KDE_DATA_TYPE_RESERVED2 = 2,
+    KDE_DATA_TYPE_MACADDR = 3,
+    KDE_DATA_TYPE_PMKID = 4,
+    KDE_DATA_TYPE_SMK = 5,
+    KDE_DATA_TYPE_NONCE = 6,
+    KDE_DATA_TYPE_LIFETIME = 7,
+    KDE_DATA_TYPE_ERROR = 8,
+    KDE_DATA_TYPE_IGTK = 9,
+} IEEEtypes_KDEDataType_e; // :777:3
+
+typedef enum {
+    PWR_MODE_ACTIVE = 0,
+    PWR_MODE_PWR_SAVE = 1,
+} IEEEtypes_PwrMgmtMode_e; // :785:3
+
+typedef UINT8 IEEEtypes_Len_t; // :948:15
+typedef UINT8 IEEEtypes_Addr_t; // :953:15
+typedef IEEEtypes_Addr_t IEEEtypes_MacAddr_t[6]; // :958:26
+typedef UINT8 IEEEtypes_SsId_t[32]; // :968:15
+typedef UINT16 IEEEtypes_BcnInterval_t; // :1183:16
+typedef UINT8 IEEEtypes_DtimPeriod_t; // :1189:15
+
+typedef struct {
+    IEEEtypes_ElementId_e ElementId;
+    IEEEtypes_Len_t Len;
+} IEEEtypes_InfoElementHdr_t; // :1246:25
+
+typedef struct {
+    IEEEtypes_ElementId_e ElementId;
+    IEEEtypes_Len_t Len;
+    IEEEtypes_SsId_t SsId;
+} IEEEtypes_SsIdElement_t; // :1266:25
+
+typedef struct {
+    IEEEtypes_ElementId_e ElementId;
+    IEEEtypes_Len_t Len;
+    UINT8 OuiType[4];
+    UINT16 Ver;
+    UINT8 GrpKeyCipher[4];
+    UINT16 PwsKeyCnt;
+    UINT8 PwsKeyCipherList[4];
+    UINT16 AuthKeyCnt;
+    UINT8 AuthKeyList[4];
+} IEEEtypes_WPAElement_t; // :2232:25
+
+typedef struct {
+    UINT8 PreAuth:1;
+    UINT8 NoPairwise:1;
+    UINT8 PtksaReplayCtr:2;
+    UINT8 GtksaReplayCtr:2;
+    UINT8 MFPR:1;
+    UINT8 MFPC:1;
+    UINT8 Reserved_8:1;
+    UINT8 PeerkeyEnabled:1;
+    UINT8 SppAmsduCap:1;
+    UINT8 SppAmsduReq:1;
+    UINT8 PBAC:1;
+    UINT8 Reserved_13_15:3;
+} IEEEtypes_RSNCapability_t; // :2251:25
+
+typedef struct {
+    IEEEtypes_ElementId_e ElementId;
+    IEEEtypes_Len_t Len;
+    UINT16 Ver;
+    UINT8 GrpKeyCipher[4];
+    UINT16 PwsKeyCnt;
+    UINT8 PwsKeyCipherList[4];
+    UINT16 AuthKeyCnt;
+    UINT8 AuthKeyList[4];
+    IEEEtypes_RSNCapability_t RsnCap;
+    UINT16 PMKIDCnt;
+    UINT8 PMKIDList[16];
+    UINT8 GrpMgmtCipher[4];
+} IEEEtypes_RSNElement_t; // :2286:25
+
+typedef enum {
+    Band_2_4_GHz = 0,
+    Band_5_GHz = 1,
+    Band_4_GHz = 2,
+} ChanBand_e; // :2672:3
+
+typedef enum {
+    ChanWidth_20_MHz = 0,
+    ChanWidth_10_MHz = 1,
+    ChanWidth_40_MHz = 2,
+    ChanWidth_80_MHz = 3,
+} ChanWidth_e; // :2682:3
+
+typedef enum {
+    SECONDARY_CHAN_NONE = 0,
+    SECONDARY_CHAN_ABOVE = 1,
+    SECONDARY_CHAN_BELOW = 3,
+} Chan2Offset_e; // :2690:3
+
+typedef enum {
+    MANUAL_MODE = 0,
+    ACS_MODE = 1,
+} ScanMode_e; // :2696:3
+
+typedef struct {
+    ChanBand_e chanBand:2;
+    ChanWidth_e chanWidth:2;
+    Chan2Offset_e chan2Offset:2;
+    ScanMode_e scanMode:2;
+} BandConfig_t; // :2712:27
+
+typedef struct {
+    BandConfig_t bandConfig;
+    UINT8 chanNum;
+} ChanBandInfo_t; // :2724:27
+
+typedef struct {
+    IEEEtypes_MacAddr_t da;
+    IEEEtypes_MacAddr_t sa;
+    UINT16 type;
+} ether_hdr_t; // :2995:25
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/KeyApiStaDefs.h ======== */
+
+typedef struct {
+    UINT8 key[16];
+    UINT8 txMicKey[8];
+    UINT8 rxMicKey[8];
+} key_Type_TKIP_t; // :60:25
+
+typedef struct {
+    UINT8 keyIndex;
+    UINT8 isDefaultTx;
+    UINT8 key[13];
+} key_Type_WEP_t; // :71:25
+
+typedef struct {
+    UINT8 key[16];
+} key_Type_AES_t; // :77:25
+
+typedef struct {
+    UINT8 keyIndex;
+    UINT8 isDefKey;
+    UINT8 key[16];
+    UINT8 mickey[16];
+    UINT8 rxPN[16];
+} key_Type_WAPI_t; // :87:25
+
+typedef struct {
+    UINT8 ipn[6];
+    UINT8 reserved[2];
+    UINT8 key[16];
+} key_Type_AES_CMAC_t; // :95:25
+
+typedef struct {
+    UINT16 keyType;
+    UINT16 keyInfo;
+    UINT16 keyLen;
+    union {
+        key_Type_TKIP_t TKIP;
+        key_Type_AES_t AES1;
+        key_Type_WEP_t WEP;
+        key_Type_WAPI_t WAPI;
+        key_Type_AES_CMAC_t iGTK;
+    } keyEncypt;
+} key_MgtMaterial_t; // :115:25
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/ap/bl_ap_init.c ======== */
+
+void InitializeAp(cm_ConnectionInfo_t *connPtr); // :124:6
+void ap_setpsk(cm_ConnectionInfo_t *connPtr, CHAR *ssid, CHAR *passphrase); // :190:6
+void ap_resetConfiguration(cm_ConnectionInfo_t *connPtr); // :205:6
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/ap/bl_ap_mgmt.c ======== */
+
+void ReInitGTK(cm_ConnectionInfo_t *connPtr); // :184:6
+void KeyMgmtInit(cm_ConnectionInfo_t *connPtr); // :244:6
+BufferDesc_t *PrepDefaultEapolMsg(cm_ConnectionInfo_t *connPtr, EAPOL_KeyMsg_Tx_t **pTxEapolPtr, BufferDesc_t *pBufDesc); // :408:15
+Status_e GeneratePWKMsg1(cm_ConnectionInfo_t *connPtr, BufferDesc_t *pBufDesc); // :451:10
+
+uint8_t int_rsn_ie[26]; // :497:9
+uint8_t rsn_len; // :498:9
+
+Status_e ProcessPWKMsg2(BufferDesc_t *pBufDesc); // :500:10
+Status_e GeneratePWKMsg3(cm_ConnectionInfo_t *connPtr, BufferDesc_t *pBufDesc); // :595:10
+Status_e ProcessPWKMsg4(BufferDesc_t *pBufDesc); // :711:10
+BOOLEAN SendEAPOLMsgUsingBufDesc(cm_ConnectionInfo_t *connPtr, BufferDesc_t *pBufDesc); // :846:9
+Status_e GenerateApEapolMsg(cm_ConnectionInfo_t *connPtr, keyMgmtState_e msgState, BufferDesc_t *pBufDesc); // :895:10
+Status_e ProcessKeyMgmtDataAp(BufferDesc_t *pBufDesc); // :986:10
+BOOLEAN IsAuthenticatorEnabled(cm_ConnectionInfo_t *connPtr); // :1046:9
+void InitStaKeyInfo(void *pConn, SecurityMode_t *secType, Cipher_t *pwCipher, UINT16 staRsnCap, UINT8 akmType); // :1288:6
+void RemoveAPKeyInfo(void *pConn); // :1351:6
+void InitGroupKey(cm_ConnectionInfo_t *connPtr); // :1364:6
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/ap/bl_ap_mgmt_internal.c ======== */
+
+void GenerateGTK_internal(KeyData_t *grpKeyData, UINT8 *nonce, IEEEtypes_Addr_t *StaMacAddr); // :68:6
+void PopulateKeyMsg(EAPOL_KeyMsg_Tx_t *tx_eapol_ptr, Cipher_t *Cipher, UINT16 Type, UINT32 *replay_cnt, UINT8 *Nonce); // :108:6
+void prepareKDE(EAPOL_KeyMsg_Tx_t *tx_eapol_ptr, KeyData_t *grKey, Cipher_t *cipher); // :179:6
+BOOLEAN Encrypt_keyData(EAPOL_KeyMsg_Tx_t *tx_eapol_ptr, UINT8 *EAPOL_Encr_Key, Cipher_t *cipher); // :248:9
+void KeyMgmtAp_DerivePTK(UINT8 *pPMK, IEEEtypes_MacAddr_t *da, IEEEtypes_MacAddr_t *sa, UINT8 *ANonce, UINT8 *SNonce, UINT8 *EAPOL_MIC_Key, UINT8 *EAPOL_Encr_Key, KeyData_t *newPWKey, BOOLEAN use_kdf); // :326:6
+BOOLEAN KeyData_CopyWPAWP2(EAPOL_KeyMsg_Tx_t *pTxEAPOL, void *pIe); // :357:9
+BOOLEAN KeyData_UpdateKeyMaterial(EAPOL_KeyMsg_Tx_t *pTxEAPOL, SecurityMode_t *pSecType, void *pWPA, void *pWPA2); // :378:9
+void ROM_InitGTK(KeyData_t *grpKeyData, UINT8 *nonce, IEEEtypes_Addr_t *StaMacAddr); // :457:6
+int validate4WayHandshakeIe(SecurityMode_t secType, Cipher_t pwCipher, Cipher_t grpCipher, apKeyMgmtInfoStaRom_t *pKeyMgmtInfo, UINT8 akmType, UINT16 rsnCap, Cipher_t config_mcstCipher); // :584:5
+void InitKeyMgmtInfo(apKeyMgmtInfoStaRom_t *pKeyMgmtInfo, SecurityMode_t *secType, Cipher_t *pwCipher, UINT16 staRsnCap, UINT8 akmType); // :619:6
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/ap/bl_connection_mgmt.c ======== */
+
+Status_e cm_AllocAPResources(cm_ConnectionInfo_t *connPtr); // :618:10
+Status_e cm_AllocResources(cm_ConnectionInfo_t *connPtr); // :671:10
+cm_ConnectionInfo_t *cm_InitConnection(UINT8 conType, UINT8 bssType, UINT8 bssNum, IEEEtypes_MacAddr_t *bssId, IEEEtypes_MacAddr_t *peerMacAddr, UINT8 channel, mdev_t *hostMdev); // :1355:22
+void cm_DeleteConnection(cm_ConnectionInfo_t *connPtr); // :2297:6
+apInfo_t *cm_GetApInfo(cm_ConnectionInfo_t *connPtr); // :3716:11
+apSpecificData_t *cm_GetApData(cm_ConnectionInfo_t *connPtr); // :3738:19
+void cm_SetPeerAddr(cm_ConnectionInfo_t *connPtr, IEEEtypes_MacAddr_t *bssId, IEEEtypes_MacAddr_t *peerMacAddr); // :5274:6
+void cm_SetComData(cm_ConnectionInfo_t *connPtr, char *ssid); // :5291:6
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/bl_aes_cmac.c ======== */
+
+static const UINT8 const_Rb[16]; // :36:20
+
+void bl_aes_128(UINT8 *key, UINT8 *input, UINT8 *output); // :43:6
+void xor_128(const UINT8 *a, const UINT8 *b, UINT8 *out); // :75:6
+void leftshift_onebit(UINT8 *input, UINT8 *output); // :86:6
+void generate_subkey(UINT8 *key, UINT8 *K1, UINT8 *K2); // :99:6
+void padding(UINT8 *lastb, UINT8 *pad, int length); // :132:6
+void bl_aes_cmac(UINT8 *key, UINT8 *input, int length, UINT8 *mac); // :154:6
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/bl_crypt.c ======== */
+
+static const UINT8 BL_DEFAULT_IV[8]; // :115:20
+
+int BL_AES_MEMCMP(UINT8 *dst, UINT8 *src, int len); // :127:5
+void BL_AES_MEMSET(UINT8 *dst, UINT8 val, int size); // :155:6
+void BL_AES_MEMCPY(UINT8 *dst, UINT8 *src, int size); // :173:6
+int BL_AesEncrypt(UINT8 *kek, UINT8 kekLen, UINT8 *data, UINT8 *ret); // :275:5
+int BL_AesWrap(UINT8 *kek, UINT8 kekLen, UINT32 n, UINT8 *plain, UINT8 *keyIv, UINT8 *cipher); // :329:5
+int BL_AesUnWrap(UINT8 *kek, UINT8 kekLen, UINT32 n, UINT8 *cipher, UINT8 *keyIv, UINT8 *plain); // :410:5
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/bl_md5_wrapper.c ======== */
+
+void Bl_hmac_md5(UINT8 *text_data, int text_len, UINT8 *key, int key_len, void *digest); // :19:6
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/bl_passphrase.c ======== */
+
+void Bl_F(unsigned char *digest, unsigned char *digest1, char *password, unsigned char *ssid, int ssidlength, int iterations, int count, unsigned char *output); // :16:6
+int Bl_PasswordHash(char *password, unsigned char *ssid, int ssidlength, unsigned char *output); // :70:5
+int bl60x_fw_password_hash(char *password, unsigned char *ssid, int ssidlength, unsigned char *output); // :85:5
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/bl_pmk_mgmt.c ======== */
+
+pmkElement_t pmkCache[2]; // :14:14
+UINT8 PSKPassPhrase[]; // :16:7
+
+UINT8 *pmkCacheFindPSK(UINT8 *pSsid, UINT8 ssidLen); // :28:9
+void pmkCacheSetPassphrase(UINT8 *pSsid, UINT8 ssidLen, UINT8 *pPassphrase, UINT8 PassphraseLen); // :69:6
+void pmkCacheInit(void); // :107:6
+void pmkCacheFlush(void); // :118:6
+void pmkCacheRomInit(void); // :128:6
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/bl_pmk_mgmt_internal.c ======== */
+
+SINT8 replacementRankMax; // :55:7
+SINT32 ramHook_MAX_PMK_CACHE_ENTRIES; // :57:8
+pmkElement_t *ramHook_pmkCache; // :59:15
+UINT8 *ramHook_PSKPassPhrase; // :60:8
+
+pmkElement_t *pmkCacheNewElement(void); // :77:15
+void pmkCacheUpdateReplacementRank(pmkElement_t *pPMKElement); // :127:6
+pmkElement_t *pmkCacheFindPSKElement(UINT8 *pSsid, UINT8 ssidLen); // :215:15
+void pmkCacheAddPSK(UINT8 *pSsid, UINT8 ssidLen, UINT8 *pPSK, UINT8 pPSKLen); // :313:6
+void pmkCacheDeletePSK(UINT8 *pSsid, UINT8 ssidLen); // :369:6
+UINT8 pmkCacheGetHexNibble(UINT8 nibble); // :388:7
+void pmkCacheGeneratePSK(UINT8 *pSsid, UINT8 ssidLen, UINT8 *pPassphrase, UINT8 PassphraseLen, UINT8 *pPSK); // :406:6
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/bl_sha1_wrapper.c ======== */
+
+void Bl_hmac_sha1(unsigned char **ppText, int *pTextLen, int textNum, unsigned char *key, int key_len, unsigned char *output, int outputLen); // :8:6
+void Bl_PRF(unsigned char *key, int key_len, unsigned char *prefix, int prefix_len, unsigned char *data, int data_len, unsigned char *output, int len); // :95:6
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/bl_sha256_crypto.c ======== */
+
+void bl_sha256_crypto_kdf(UINT8 *pKey, UINT8 key_len, char *label, UINT8 label_len, UINT8 *pContext, UINT16 context_len, UINT8 *pOutput, UINT16 output_len); // :72:6
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/bl_sta_mgmt.c ======== */
+
+static supplicantData_t keyMgmt_SuppData[1]; // :125:25
+
+UINT8 ProcessEAPoLPkt(BufferDesc_t *bufDesc, IEEEtypes_MacAddr_t *sa, IEEEtypes_MacAddr_t *da); // :172:7
+BufferDesc_t *GetTxEAPOLBuffer(cm_ConnectionInfo_t *connPtr, EAPOL_KeyMsg_Tx_t **ppTxEapol, BufferDesc_t *pBufDesc); // :215:15
+void allocSupplicantData(void *connectionPtr); // :297:6
+void freeSupplicantData(void *connectionPtr); // :331:6
+void UpdateEAPOLWcbLenAndTransmit(BufferDesc_t *pBufDesc, UINT16 frameLen); // :347:6
+BOOLEAN keyMgmtProcessMsgExt(keyMgmtInfoSta_t *pKeyMgmtInfoSta, EAPOL_KeyMsg_t *pKeyMsg); // :387:9
+void KeyMgmtInitSta(cm_ConnectionInfo_t *connPtr); // :538:6
+Status_e GeneratePWKMsg2(BufferDesc_t *pEAPoLBufDesc, UINT8 *pSNonce, UINT8 *pEAPOLMICKey, UINT8 forceKeyDescVersion); // :547:10
+Status_e GeneratePWKMsg4(BufferDesc_t *pEAPoLBufDesc, keyMgmtInfoSta_t *pKeyMgmtInfoSta, BOOLEAN groupKeyReceived); // :612:10
+Status_e GenerateGrpMsg2(BufferDesc_t *pEAPoLBufDesc, keyMgmtInfoSta_t *pKeyMgmtInfoSta); // :686:10
+BOOLEAN KeyMgmtStaHsk_Recvd_PWKMsg1(BufferDesc_t *pEAPoLBufDesc, IEEEtypes_MacAddr_t *sa, IEEEtypes_MacAddr_t *da); // :732:9
+const EAPOL_KeyMsg_t *KeyMgmtStaHsk_Recvd_PWKMsg3(BufferDesc_t *pEAPoLBufDesc); // :878:23
+const EAPOL_KeyMsg_t *KeyMgmtStaHsk_Recvd_GrpMsg1(BufferDesc_t *pEAPoLBufDesc); // :917:23
+void ProcessKeyMgmtDataSta(BufferDesc_t *pBufDesc, IEEEtypes_MacAddr_t *sa, IEEEtypes_MacAddr_t *da); // :953:6
+void keyMgmtSta_StartSession(cm_ConnectionInfo_t *connPtr, CHAR *pBssid, UINT8 *pStaAddr); // :1185:6
+void supplicantInitSession(cm_ConnectionInfo_t *connPtr, CHAR *pSsid, UINT16 len, CHAR *pBssid, UINT8 *pStaAddr); // :1405:6
+void init_customApp_mibs(supplicantData_t *suppData); // :1431:6
+UINT8 supplicantIsEnabled(void *connectionPtr); // :1457:7
+void supplicantDisable(cm_ConnectionInfo_t *connPtr); // :1472:6
+void supplicantEnable(void *connectionPtr, int security_mode, void *mcstCipher, void *ucstCipher, bool is_pmf_required); // :1487:6
+UINT16 keyMgmtFormatWpaRsnIe(cm_ConnectionInfo_t *connPtr, UINT8 *pos, IEEEtypes_MacAddr_t *pBssid, IEEEtypes_MacAddr_t *pStaAddr, UINT8 *pPmkid, BOOLEAN addPmkid); // :1563:8
+void supplicantInit(supplicantData_t *suppData); // :1674:6
+UINT16 keyMgmtGetKeySize(cm_ConnectionInfo_t *connPtr, UINT8 isPairwise); // :1711:8
+uint8_t add_key_to_mac(cm_ConnectionInfo_t *connPtr, UINT8 pairwise); // :1847:9
+uint8_t add_mfp_key_to_mac(cm_ConnectionInfo_t *connPtr, UINT8 pairwise); // :1934:9
+void keyMgmtPlumbPairwiseKey(cm_ConnectionInfo_t *connPtr); // :1980:6
+void supplicantRemoveKeyInfo(cm_ConnectionInfo_t *connPtr); // :2317:6
+
+struct _wpa_suite_t {
+    uint8_t oui[3];
+    uint8_t type;
+}; // :2331:16
+
+typedef struct _wpa_suite_t wpa_suite_mcast_t; // :2337:38
+typedef struct _wpa_suite_t wpa_suite; // :2337:27
+
+typedef struct {
+    uint16_t count;
+    wpa_suite list[2];
+} wpa_suite_auth_key_mgmt_t; // :2346:46
+
+typedef struct {
+    uint16_t count;
+    wpa_suite list[2];
+} wpa_suite_ucast_t; // :2346:27
+
+struct _IEEEtypes_Rsn_t {
+    uint8_t element_id;
+    uint8_t len;
+    uint16_t version;
+    wpa_suite_mcast_t group_cipher;
+    wpa_suite_ucast_t pairwise_cipher;
+    wpa_suite_auth_key_mgmt_t auth_key_mgmt;
+}; // :2348:16
+
+typedef struct _IEEEtypes_Rsn_t IEEEtypes_Rsn_t; // :2362:27
+
+struct _IEEEtypes_Wpa_t {
+    uint8_t element_id;
+    uint8_t len;
+    uint8_t oui[4];
+    uint16_t version;
+    wpa_suite_mcast_t group_cipher;
+    wpa_suite_ucast_t pairwise_cipher;
+    wpa_suite_auth_key_mgmt_t auth_key_mgmt;
+}; // :2365:16
+
+typedef struct _IEEEtypes_Wpa_t IEEEtypes_Wpa_t; // :2381:27
+
+unsigned char process_rsn_ie(uint8_t *rsn_ie, Cipher_t *mcstCipher, Cipher_t *ucstCipher, bool *is_pmf_required, SecurityMode_t *security_mode, bool wpa2_prefered); // :2383:15
+unsigned char process_wpa_ie(uint8_t *wpa_ie, Cipher_t *mcstCipher, Cipher_t *ucstCipher); // :2506:15
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/bl_sta_mgmt_internal.c ======== */
+
+const UINT8 wpa_oui_none[4]; // :191:13
+const UINT8 wpa_oui01[4]; // :192:13
+const UINT8 wpa_oui02[4]; // :193:13
+const UINT8 wpa_oui03[4]; // :194:13
+const UINT8 wpa_oui04[4]; // :195:13
+const UINT8 wpa_oui05[4]; // :196:13
+const UINT8 wpa_oui06[4]; // :197:13
+const UINT8 wpa2_oui01[4]; // :199:13
+const UINT8 wpa2_oui02[4]; // :200:13
+const UINT8 wpa2_oui03[4]; // :201:13
+const UINT8 wpa2_oui04[4]; // :202:13
+const UINT8 wpa2_oui05[4]; // :203:13
+const UINT8 wpa2_oui06[4]; // :204:13
+const UINT8 wpa2_oui08[4]; // :205:13
+const UINT8 wpa_oui[3]; // :207:13
+const UINT8 kde_oui[3]; // :208:13
+
+void supplicantGenerateRand(UINT8 *dataOut, UINT32 length); // :210:6
+void ComputeEAPOL_MIC(EAPOL_KeyMsg_t *pKeyMsg, UINT16 data_length, UINT8 *MIC_Key, UINT8 MIC_Key_length, UINT8 micKeyDescVersion); // :219:6
+UINT16 keyMgmtGetKeySize_internal(RSNConfig_t *pRsnConfig, UINT8 isPairwise); // :971:8
+int isApReplayCounterFresh(keyMgmtInfoSta_t *pKeyMgmtInfoSta, UINT8 *pRxReplayCount); // :1044:5
+void updateApReplayCounter(keyMgmtInfoSta_t *pKeyMgmtStaInfo, UINT8 *pRxReplayCount); // :1093:6
+void formEAPOLEthHdr(EAPOL_KeyMsg_Tx_t *pTxEapol, IEEEtypes_MacAddr_t *da, IEEEtypes_MacAddr_t *sa); // :1210:6
+BOOLEAN IsEAPOL_MICValid(EAPOL_KeyMsg_t *pKeyMsg, UINT8 *pMICKey); // :1225:9
+UINT16 KeyMgmtSta_PopulateEAPOLLengthMic(EAPOL_KeyMsg_Tx_t *pTxEapol, UINT8 *pEAPOLMICKey, UINT8 eapolProtocolVersion, UINT8 forceKeyDescVersion); // :1262:8
+KDE_t *parseKeyKDE(IEEEtypes_InfoElementHdr_t *pIe); // :1314:8
+KDE_t *parseKeyKDE_DataType(UINT8 *pData, SINT32 dataLen, IEEEtypes_KDEDataType_e KDEDataType); // :1343:8
+KDE_t *parseKeyDataGTK(UINT8 *pKey, UINT16 len, KeyData_t *pGRKey); // :1402:8
+void KeyMgmtSta_ApplyKEK(EAPOL_KeyMsg_t *pKeyMsg, KeyData_t *pGRKey, UINT8 *EAPOL_Encr_Key); // :1448:6
+BOOLEAN KeyMgmtSta_IsRxEAPOLValid(keyMgmtInfoSta_t *pKeyMgmtInfoSta, EAPOL_KeyMsg_t *pKeyMsg); // :1520:9
+void KeyMgmtSta_PrepareEAPOLFrame(EAPOL_KeyMsg_Tx_t *pTxEapol, EAPOL_KeyMsg_t *pRxEapol, IEEEtypes_MacAddr_t *da, IEEEtypes_MacAddr_t *sa, UINT8 *pSNonce); // :1585:6
+BOOLEAN supplicantAkmIsWpaWpa2(AkmSuite_t *pAkm); // :1670:9
+BOOLEAN supplicantAkmIsWpa2(AkmSuite_t *pAkm); // :1684:9
+BOOLEAN supplicantAkmIsWpaWpa2Psk(AkmSuite_t *pAkm); // :1698:9
+BOOLEAN supplicantAkmUsesKdf(AkmSuite_t *pAkm); // :1712:9
+void supplicantConstructContext(IEEEtypes_MacAddr_t *pAddr1, IEEEtypes_MacAddr_t *pAddr2, UINT8 *pNonce1, UINT8 *pNonce2, UINT8 *pContext); // :1761:6
+void KeyMgmt_DerivePTK(IEEEtypes_MacAddr_t *pAddr1, IEEEtypes_MacAddr_t *pAddr2, UINT8 *pNonce1, UINT8 *pNonce2, UINT8 *pPTK, UINT8 *pPMK, BOOLEAN use_kdf); // :1868:6
+void KeyMgmtSta_DeriveKeys(UINT8 *pPMK, IEEEtypes_MacAddr_t *da, IEEEtypes_MacAddr_t *sa, UINT8 *ANonce, UINT8 *SNonce, UINT8 *EAPOL_MIC_Key, UINT8 *EAPOL_Encr_Key, KeyData_t *newPWKey, BOOLEAN use_kdf); // :1932:6
+void SetEAPOLKeyDescTypeVersion(EAPOL_KeyMsg_Tx_t *pTxEapol, BOOLEAN isWPA2, BOOLEAN isKDF, BOOLEAN nonTKIP); // :1994:6
+EAPOL_KeyMsg_t *GetKeyMsgNonceFromEAPOL(BufferDesc_t *pEAPoLBufDesc, keyMgmtInfoSta_t *pKeyMgmtInfoSta); // :2034:17
+EAPOL_KeyMsg_t *ProcessRxEAPOL_PwkMsg3(BufferDesc_t *pEAPoLBufDesc, keyMgmtInfoSta_t *pKeyMgmtInfoSta); // :2061:17
+EAPOL_KeyMsg_t *ProcessRxEAPOL_GrpMsg1(BufferDesc_t *pEAPoLBufDesc, keyMgmtInfoSta_t *pKeyMgmtInfoSta); // :2103:17
+void KeyMgmtResetCounter(keyMgmtInfoSta_t *pKeyMgmtInfo); // :2155:6
+void keyMgmtStaRsnSecuredTimeoutHandler(void *env); // :2219:6
+void keyMgmtSta_StartSession_internal(keyMgmtInfoSta_t *pKeyMgmtInfoSta, UINT32 expiry); // :2251:6
+void KeyMgmtSta_InitSession(keyMgmtInfoSta_t *pKeyMgmtInfoSta); // :2342:6
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/bl_sta_mgmt_others.c ======== */
+
+NoHostSecurityParams_t nohostParams; // :28:24
+
+void set_psk(char *pSsid, UINT8 ssidLen, char *phrase); // :30:6
+void set_pmk(char *pSsid, UINT8 ssidLen, char *pPMK); // :43:6
+char *get_pmk(char *pSsid, UINT8 ssidLen); // :53:7
+void remove_psk(char *pSsid, UINT8 ssidLen); // :60:6
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/bl_supplicant.c ======== */
+
+Status_e supplicantRestoreDefaults(void); // :38:10
+void supplicantFuncInit(void); // :49:6
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/bufferMgmtLib.h ======== */
+
+typedef void (*BufferReturnNotify_t)(void); // :66:16
+
+struct BufferDesc {
+    union {
+        uint32 Interface;
+        struct cm_ConnectionInfo *connPtr;
+    } intf;
+    uint16 DataLen;
+    void *Buffer;
+}; // :71:16
+
+typedef struct BufferDesc BufferDesc_t; // :119:3
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/crypt_new_rom.h ======== */
+
+typedef struct {
+    UINT8 enDeAction;
+    UINT8 *pData;
+} BL_ENDECRYPT_t; // :56:3
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/customApp_mib.h ======== */
+
+typedef struct {
+    UINT8 RSNEnabled:1;
+    UINT8 pmkidValid:1;
+    UINT8 rsnCapValid:1;
+    UINT8 grpMgmtCipherValid:1;
+    UINT8 rsvd:4;
+    SecurityMode_t wpaType;
+    Cipher_t mcstCipher;
+    Cipher_t ucstCipher;
+    AkmSuite_t AKM;
+    UINT8 PMKID[16];
+    IEEEtypes_RSNCapability_t rsnCap;
+    Cipher_t grpMgmtCipher;
+} RSNConfig_t; // :37:3
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/keyApiStaTypes.h ======== */
+
+struct cipher_key_buf {
+    cipher_key_t cipher_key;
+}; // :157:16
+
+typedef struct cipher_key_buf cipher_key_buf_t; // :165:27
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/keyApiStaTypes_rom.h ======== */
+
+typedef struct {
+    UINT8 ANonce[32];
+    KeyData_t pwsKeyData;
+} eapolHskData_t; // :98:27
+
+struct cipher_key_t {
+    union ckd ckd;
+}; // :101:16
+
+union ckd {
+    eapolHskData_t hskData;
+}; // :106:11
+
+typedef struct cipher_key_t cipher_key_t; // :115:27
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/keyMgmtApTypes.h ======== */
+
+typedef struct {
+    apKeyMgmtInfoStaRom_t rom;
+    UINT8 numHskTries;
+    UINT32 counterLo;
+    UINT32 counterHi;
+    struct mm_timer_tag HskTimer;
+    UINT8 EAPOL_MIC_Key[16];
+    UINT8 EAPOL_Encr_Key[16];
+    UINT8 EAPOLProtoVersion;
+    UINT8 rsvd[3];
+} apKeyMgmtInfoSta_t; // :46:3
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/keyMgmtApTypes_rom.h ======== */
+
+typedef enum {
+    HSK_NOT_STARTED = 0,
+    MSG1_PENDING = 1,
+    WAITING_4_MSG2 = 2,
+    MSG3_PENDING = 3,
+    WAITING_4_MSG4 = 4,
+    GRPMSG1_PENDING = 5,
+    WAITING_4_GRPMSG2 = 6,
+    GRP_REKEY_MSG1_PENDING = 7,
+    WAITING_4_GRP_REKEY_MSG2 = 8,
+    HSK_DUMMY_STATE = 9,
+    HSK_END = 10,
+} keyMgmtState_e; // :35:3
+
+typedef struct {
+    UINT16 staRsnCap;
+    SecurityMode_t staSecType;
+    Cipher_t staUcstCipher;
+    UINT8 staAkmType;
+    keyMgmtState_e keyMgmtState;
+} apKeyMgmtInfoStaRom_t; // :45:3
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/keyMgmtCommon.h ======== */
+
+typedef struct {
+    UINT8 protocol_ver;
+    IEEEtypes_8021x_PacketType_e pckt_type;
+    UINT16 pckt_body_len;
+} Hdr_8021x_t; // :36:25
+
+typedef struct {
+    UINT16 KeyMIC:1;
+    UINT16 Secure:1;
+    UINT16 Error:1;
+    UINT16 Request:1;
+    UINT16 EncryptedKeyData:1;
+    UINT16 Reserved:3;
+    UINT16 KeyDescriptorVersion:3;
+    UINT16 KeyType:1;
+    UINT16 KeyIndex:2;
+    UINT16 Install:1;
+    UINT16 KeyAck:1;
+} key_info_t; // :59:27
+
+typedef struct {
+    UINT8 KeyID:2;
+    UINT8 Tx:1;
+    UINT8 rsvd:5;
+    UINT8 rsvd1;
+    UINT8 GTK[1];
+} GTK_KDE_t; // :73:25
+
+typedef struct {
+    UINT8 type;
+    UINT8 length;
+    UINT8 OUI[3];
+    UINT8 dataType;
+    UINT8 data[1];
+} KDE_t; // :84:25
+
+typedef struct {
+    Hdr_8021x_t hdr_8021x;
+    UINT8 desc_type;
+    key_info_t key_info;
+    UINT16 key_length;
+    UINT32 replay_cnt[2];
+    UINT8 key_nonce[32];
+    UINT8 EAPOL_key_IV[16];
+    UINT8 key_RSC[8];
+    UINT8 key_ID[8];
+    UINT8 key_MIC[16];
+    UINT16 key_material_len;
+    UINT8 key_data[1];
+} EAPOL_KeyMsg_t; // :109:25
+
+typedef struct {
+    Hdr_8021x_t hdr_8021x;
+    IEEEtypes_8021x_CodeType_e code;
+    UINT8 identifier;
+    UINT16 length;
+    UINT8 data[1];
+} EAP_PacketMsg_t; // :120:25
+
+typedef struct {
+    ether_hdr_t ethHdr;
+    EAPOL_KeyMsg_t keyMsg;
+} EAPOL_KeyMsg_Tx_t; // :128:25
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/keyMgmtSta.h ======== */
+
+struct supplicantData {
+    BOOLEAN inUse;
+    IEEEtypes_SsIdElement_t hashSsId;
+    IEEEtypes_MacAddr_t localBssid;
+    IEEEtypes_MacAddr_t localStaAddr;
+    customMIB_RSNStats_t customMIB_RSNStats;
+    RSNConfig_t customMIB_RSNConfig;
+    keyMgmtInfoSta_t keyMgmtInfoSta;
+    SecurityParams_t currParams;
+}; // :37:16
+
+typedef struct supplicantData supplicantData_t; // :47:3
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/keyMgmtStaHostTypes_rom.h ======== */
+
+typedef struct {
+    UINT8 Key[16];
+    UINT8 RxMICKey[8];
+    UINT8 TxMICKey[8];
+    UINT32 TxIV32;
+    UINT16 TxIV16;
+    UINT16 KeyIndex;
+} KeyData_t; // :14:3
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/keyMgmtStaTypes.h ======== */
+
+typedef struct {
+    UINT8 wep40:1;
+    UINT8 wep104:1;
+    UINT8 tkip:1;
+    UINT8 ccmp:1;
+    UINT8 rsvd:4;
+} Cipher_t; // :34:3
+
+typedef struct {
+    UINT16 noRsn:1;
+    UINT16 wepStatic:1;
+    UINT16 wepDynamic:1;
+    UINT16 wpa:1;
+    UINT16 wpaNone:1;
+    UINT16 wpa2:1;
+    UINT16 cckm:1;
+    UINT16 wapi:1;
+    UINT16 wpa3:1;
+    UINT16 rsvd:7;
+} SecurityMode_t; // :50:27
+
+typedef enum {
+    AKM_NONE = 0,
+    AKM_1X = 1,
+    AKM_PSK = 2,
+    AKM_FT_1X = 3,
+    AKM_FT_PSK = 4,
+    AKM_SHA256_1X = 5,
+    AKM_SHA256_PSK = 6,
+    AKM_TDLS = 7,
+    AKM_CCKM = 99,
+    AKM_WPA_MAX = 2,
+    AKM_RSN_MAX = 6,
+    AKM_SUITE_MAX = 5,
+} AkmType_e; // :71:27
+
+typedef AkmType_e AkmTypePacked_e; // :73:19
+
+typedef struct {
+    UINT8 akmOui[3];
+    AkmTypePacked_e akmType;
+} AkmSuite_t; // :80:3
+
+typedef struct {
+    SecurityMode_t wpaType;
+    Cipher_t mcstCipher;
+    Cipher_t ucstCipher;
+} SecurityParams_t; // :88:3
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/keyMgmtSta_rom.h ======== */
+
+typedef enum {
+    NO_MIC_FAILURE = 0,
+    FIRST_MIC_FAIL_IN_60_SEC = 1,
+    SECOND_MIC_FAIL_IN_60_SEC = 2,
+} MIC_Fail_State_e; // :31:3
+
+typedef struct {
+    MIC_Fail_State_e status;
+    BOOLEAN MICCounterMeasureEnabled;
+    UINT32 disableStaAsso;
+} MIC_Error_t; // :39:3
+
+typedef struct {
+    UINT8 TKIPICVErrors;
+    UINT8 TKIPLocalMICFailures;
+    UINT8 TKIPCounterMeasuresInvoked;
+} customMIB_RSNStats_t; // :47:3
+
+typedef struct {
+    UINT8 ANonce[32];
+    UINT8 SNonce[32];
+    UINT8 EAPOL_MIC_Key[16];
+    UINT8 EAPOL_Encr_Key[16];
+    UINT32 apCounterLo;
+    UINT32 apCounterHi;
+    UINT32 apCounterZeroDone;
+    UINT32 staCounterLo;
+    UINT32 staCounterHi;
+    BOOLEAN RSNDataTrafficEnabled;
+    BOOLEAN RSNSecured;
+    BOOLEAN pwkHandshakeComplete;
+    cipher_key_t *pRxDecryptKey;
+    KeyData_t PWKey;
+    KeyData_t GRKey;
+    KeyData_t newPWKey;
+    MIC_Error_t sta_MIC_Error;
+    struct mm_timer_tag rsnTimer;
+    struct cm_ConnectionInfo *connPtr;
+    KeyData_t IGtk;
+} keyMgmtInfoSta_t; // :82:3
+
+typedef struct {
+    UINT8 kck[16];
+    UINT8 kek[16];
+    UINT8 tk[16];
+    UINT8 rxMicKey[8];
+    UINT8 txMicKey[8];
+} TkipPtk_t; // :100:3
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/macMgmtMain.h ======== */
+
+typedef struct {
+    IEEEtypes_SsId_t SsId;
+    IEEEtypes_Len_t SsIdLen;
+    IEEEtypes_DtimPeriod_t DtimPeriod;
+    IEEEtypes_BcnInterval_t BcnPeriod;
+    IEEEtypes_MacAddr_t BssId;
+    UINT16 RtsThresh;
+    UINT16 FragThresh;
+    UINT8 ShortRetryLim;
+    UINT8 LongRetryLim;
+    UINT8 MbssBcnIntFac;
+    UINT8 MbssCurBcnIntCnt;
+    UINT16 Reserved;
+} CommonMlmeData_t; // :367:3
+
+struct _txQingInfo_t {
+    IEEEtypes_PwrMgmtMode_e mode;
+}; // :426:16
+
+typedef struct _txQingInfo_t txQingInfo_t; // :439:1
+
+typedef struct {
+    UINT16 keyExchange:1;
+    UINT16 authenticate:1;
+    UINT16 reserved:14;
+} Operation_t; // :550:2
+
+typedef struct {
+    Cipher_t mcstCipher;
+    UINT8 mcstCipherCount;
+    Cipher_t wpaUcstCipher;
+    UINT8 wpaUcstCipherCount;
+    Cipher_t wpa2UcstCipher;
+    UINT8 wpa2UcstCipherCount;
+    UINT16 AuthKey;
+    UINT16 AuthKeyCount;
+    Operation_t Akmp;
+    UINT32 GrpReKeyTime;
+    UINT8 PSKPassPhrase[64];
+    UINT8 PSKPassPhraseLen;
+    UINT8 PSKValue[32];
+    UINT8 MaxPwsHskRetries;
+    UINT8 MaxGrpHskRetries;
+    UINT32 PwsHskTimeOut;
+    UINT32 GrpHskTimeOut;
+} apRsnConfig_t; // :577:3
+
+typedef struct {
+    UINT32 StaAgeOutTime;
+    UINT32 PsStaAgeOutTime;
+    apRsnConfig_t RsnConfig;
+    CommonMlmeData_t comData;
+} BssConfig_t; // :695:3
+
+typedef struct {
+    BOOLEAN updatePassPhrase;
+    struct mm_timer_tag apMicTimer;
+    KeyData_t grpKeyData;
+    UINT8 GNonce[32];
+    UINT32 grpRekeyBcnCntConfigured;
+    UINT32 grpRekeyBcnCntRemaining;
+} BssData_t; // :813:3
+
+typedef struct {
+    txQingInfo_t pwrSaveInfo;
+    apKeyMgmtInfoSta_t keyMgmtInfo;
+} staData_t; // :879:3
+
+typedef struct {
+    BssConfig_t bssConfig;
+    BssData_t bssData;
+    UINT8 ApStop_Req_Pending;
+} apInfo_t; // :886:3
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/md5.c ======== */
+
+static const unsigned char PADDING[64]; // :38:28
+
+void wpa_MD5Init(Bl_MD5_CTX *context); // :82:6
+void wpa_MD5Update(Bl_MD5_CTX *context, UINT8 *input, UINT32 inputLen); // :96:6
+void wpa_MD5Final(unsigned char *digest, Bl_MD5_CTX *context); // :140:6
+static void wpa_MD5Transform(UINT32 *state, unsigned long *block); // :166:13
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/md5.h ======== */
+
+typedef struct {
+    unsigned long state[4];
+    unsigned long count[2];
+    unsigned long scratch[16];
+    unsigned char buffer[64];
+} Bl_MD5_CTX; // :23:1
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/nohostSecurityParams.h ======== */
+
+typedef struct {
+    UINT8 CipherType;
+    UINT8 MulticastCipher;
+    UINT8 UnicastCipher;
+    char PSKPassPhrase[64];
+} NoHostSecurityParams_t; // :23:3
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/pmkCache.h ======== */
+
+UINT8 PSKPassPhrase[]; // :8:14
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/pmkCache_rom.h ======== */
+
+typedef struct {
+    union {
+        IEEEtypes_MacAddr_t Bssid;
+        char Ssid[32];
+    } key;
+    UINT8 PMK[32];
+    UINT8 length;
+    UINT8 psk_length;
+    SINT8 replacementRank;
+} pmkElement_t; // :31:3
+
+SINT8 replacementRankMax; // :104:14
+SINT32 ramHook_MAX_PMK_CACHE_ENTRIES; // :107:15
+pmkElement_t *ramHook_pmkCache; // :108:23
+UINT8 *ramHook_PSKPassPhrase; // :109:16
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/rc4.c ======== */
+
+struct rc4_key {
+    unsigned char state[256];
+    unsigned char x;
+    unsigned char y;
+}; // :5:16
+
+typedef struct rc4_key rc4_key; // :10:3
+
+static rc4_key rc4key; // :12:16
+
+void prepare_key(unsigned char *key_data_ptr, int key_data_len, rc4_key *key); // :16:6
+void rc4(unsigned char *buffer_ptr, int buffer_len, int skip, rc4_key *key); // :43:6
+void RC4_Encrypt(unsigned char *Encr_Key, unsigned char *IV, unsigned short iv_length, unsigned char *Data, unsigned short data_length, unsigned short skipBytes); // :86:6
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/rijndael.c ======== */
+
+static const u32 Te0[256]; // :59:18
+static const u32 Te1[256]; // :125:18
+static const u32 Te2[256]; // :191:18
+static const u32 Te3[256]; // :257:18
+static const u8 Te4[256]; // :325:17
+static const u32 Td0[256]; // :392:18
+static const u32 Td1[256]; // :458:18
+static const u32 Td2[256]; // :524:18
+static const u32 Td3[256]; // :591:18
+static const u8 Td4[256]; // :657:17
+static const u32 rcon[10]; // :724:18
+
+static int rijndaelKeySetupEnc(u32 *rk, const u8 *cipherKey, int keyBits); // :738:12
+void rijndael_set_key(rijndael_ctx *ctx, u8 *key, int bits, int encrypt); // :1183:1
+void rijndael_decrypt(rijndael_ctx *ctx, u8 *src, u8 *dst); // :1195:1
+void rijndael_encrypt(rijndael_ctx *ctx, u8 *src, u8 *dst); // :1202:1
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/rijndael.h ======== */
+
+typedef unsigned char u8; // :44:23
+typedef unsigned int u32; // :46:22
+
+typedef struct {
+    int decrypt;
+    int Nr;
+    u32 key[60];
+} rijndael_ctx; // :53:3
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/sae/bl_buf.c ======== */
+
+struct wpabuf *wpabuf_alloc(size_t len); // :15:17
+void wpabuf_free(struct wpabuf *buf); // :30:6
+void *wpabuf_put(struct wpabuf *buf, size_t len); // :45:8
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/sae/bl_buf.h ======== */
+
+struct wpabuf {
+    size_t size;
+    size_t used;
+    uint8 *ext_data;
+}; // :14:8
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/sae/bl_sae.c ======== */
+
+void wpabuf_clear_free(struct wpabuf *buf); // :147:6
+void bin_clear_free(void *bin, size_t len); // :155:6
+sint32 sae_set_group(struct sae_data *sae, sint32 group); // :163:8
+void sae_clear_temp_data(struct sae_data *sae); // :222:6
+void sae_clear_data(struct sae_data *sae); // :245:6
+static void buf_shift_right(uint8 *buf, size_t len, size_t bits); // :254:13
+static sint32 sae_derive_pwe_ecc(struct sae_data *sae, const uint8 *addr1, const uint8 *addr2, const uint8 *password, size_t password_len, const char *identifier); // :560:15
+sint32 sae_prepare_commit(const uint8 *addr1, const uint8 *addr2, const uint8 *password, size_t password_len, const char *identifier, struct sae_data *sae); // :856:8
+sint32 sae_process_commit(struct sae_data *sae); // :993:8
+sint32 sae_write_commit(struct sae_data *sae, struct wpabuf *buf, const struct wpabuf *token, const char *identifier); // :1007:8
+uint16 sae_group_allowed(struct sae_data *sae, sint32 *allowed_groups, uint16 group); // :1064:8
+static sint32 sae_is_password_id_elem(const uint8 *pos, const uint8 *end); // :1105:15
+uint16 sae_parse_commit(struct sae_data *sae, const uint8 *data, size_t len, const uint8 **token, size_t *token_len, sint32 *allowed_groups); // :1353:8
+static sint32 sae_cn_confirm_ecc(struct sae_data *sae, const uint8 *sc, const struct crypto_bignum *scalar1, const struct crypto_ec_point *element1, const struct crypto_bignum *scalar2, const struct crypto_ec_point *element2, uint8 *confirm); // :1448:15
+static sint32 sae_cn_confirm_ffc(struct sae_data *sae, const uint8 *sc, const struct crypto_bignum *scalar1, const struct crypto_bignum *element1, const struct crypto_bignum *scalar2, const struct crypto_bignum *element2, uint8 *confirm); // :1474:15
+sint32 sae_write_confirm(struct sae_data *sae, struct wpabuf *buf); // :1500:8
+sint32 sae_check_confirm(struct sae_data *sae, const uint8 *data, size_t len); // :1538:8
+const char *sae_state_txt(enum sae_state state); // :1586:14
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/sae/bl_sae.h ======== */
+
+struct sae_temporary_data {
+    uint8 kck[32];
+    struct crypto_bignum *own_commit_scalar;
+    struct crypto_bignum *own_commit_element_ffc;
+    struct crypto_ec_point *own_commit_element_ecc;
+    struct crypto_bignum *peer_commit_element_ffc;
+    struct crypto_ec_point *peer_commit_element_ecc;
+    struct crypto_ec_point *pwe_ecc;
+    struct crypto_bignum *pwe_ffc;
+    struct crypto_bignum *sae_rand;
+    struct crypto_ec *ec;
+    sint32 prime_len;
+    const struct dh_group *dh;
+    const struct crypto_bignum *prime;
+    const struct crypto_bignum *order;
+    struct crypto_bignum *prime_buf;
+    struct crypto_bignum *order_buf;
+    struct wpabuf *anti_clogging_token;
+    char *pw_id;
+}; // :25:8
+
+enum sae_state {
+    SAE_NOTHING = 0,
+    SAE_COMMITTED = 1,
+    SAE_CONFIRMED = 2,
+    SAE_ACCEPTED = 3,
+}; // :51:6
+
+struct sae_data {
+    enum sae_state state;
+    uint16 send_confirm;
+    uint8 pmk[32];
+    uint8 pmkid[16];
+    struct crypto_bignum *peer_commit_scalar;
+    sint32 group;
+    uint32 sync;
+    uint16 rc;
+    struct sae_temporary_data *tmp;
+}; // :55:8
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/sha1.c ======== */
+
+int Bl_SHA1Init(Bl_SHA1_CTX *context); // :38:5
+int Bl_SHA1Final(Bl_SHA1_CTX *context, UINT8 *Message_Digest); // :80:5
+int Bl_SHA1Update(Bl_SHA1_CTX *context, const UINT8 *message_array, unsigned int length); // :140:5
+static void Bl_SHA1ProcessMessageBlock(Bl_SHA1_CTX *context); // :236:6
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/sha1.h ======== */
+
+typedef struct {
+    UINT32 Intermediate_Hash[5];
+    UINT32 Length_Low;
+    UINT32 Length_High;
+    UINT32 Scratch[16];
+    UINT8 Message_Block[64];
+    SINT16 Message_Block_Index;
+    UINT8 Computed;
+    UINT8 Corrupted;
+} Bl_SHA1_CTX; // :46:1
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/sha256.c ======== */
+
+void hmac_sha256_vector(const UINT8 *key, size_t key_len, size_t num_elem, const UINT8 **addr, const size_t *len, UINT8 *mac); // :51:6
+void sha256_vector(size_t num_elem, const UINT8 **addr, size_t *len, UINT8 *mac, UINT8 *pScratchMem); // :151:6
+
+static const unsigned long K[64]; // :190:28
+
+int sha256_compress(struct sha256_state *md, UINT8 *msgBuf, UINT8 *pScratchMem); // :232:5
+void sha256_init(struct sha256_state *md); // :302:6
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/sha_256.h ======== */
+
+struct sha256_state {
+    UINT64 length;
+    UINT32 state[8];
+    UINT32 curlen;
+    UINT8 buf[64];
+}; // :23:8
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/w81connmgr.h ======== */
+
+typedef struct {
+    apInfo_t *apInfo;
+    BufferDesc_t *apInfoBuffDesc;
+    ChanBandInfo_t chanBandInfo;
+    staData_t staData;
+} apSpecificData_t; // :345:3
+
+struct cm_ConnectionInfo {
+    UINT8 conType;
+    UINT8 staId;
+    UINT8 instNbr;
+    UINT8 gtkHwKeyId;
+    UINT8 ptkHwKeyId;
+    UINT8 mfpHwKeyId;
+    struct supplicantData *suppData;
+    CommonMlmeData_t comData;
+    IEEEtypes_MacAddr_t peerMacAddr;
+    IEEEtypes_MacAddr_t localMacAddr;
+    union {
+        apSpecificData_t apData;
+    } specDat;
+    cipher_key_buf_t TxRxCipherKeyBuf;
+}; // :787:16
+
+typedef struct cm_ConnectionInfo cm_ConnectionInfo_t; // :807:3
+
+cm_ConnectionInfo_t sta_conn_info; // :822:28
+cm_ConnectionInfo_t *uap_conn_info; // :823:29
+
+/* ======== components/bl602/bl602_wifi/modules/supplicant/src/wltypes.h ======== */
+
+typedef long long unsigned int UINT64; // :29:28
+typedef unsigned long UINT32; // :31:23
+typedef long SINT32; // :32:21
+typedef unsigned short UINT16; // :33:24
+typedef short SINT16; // :34:22
+typedef unsigned char UINT8; // :35:23
+typedef signed char SINT8; // :36:21
+typedef unsigned long uint32; // :40:23
+typedef int sint32; // :42:20
+typedef unsigned short uint16; // :43:24
+typedef unsigned char uint8; // :45:23
+typedef int BOOLEAN; // :48:13
+typedef char CHAR; // :53:14
+
+typedef enum {
+    FW_SUCCESS = 0,
+    FAIL = 1,
+} Status_e; // :113:3
+
+typedef void mdev_t; // :661:14
+
+enum wlan_security_type {
+    WLAN_SECURITY_NONE = 0,
+    WLAN_SECURITY_WEP_OPEN = 1,
+    WLAN_SECURITY_WEP_SHARED = 2,
+    WLAN_SECURITY_WPA = 3,
+    WLAN_SECURITY_WPA2 = 4,
+    WLAN_SECURITY_WPA_WPA2_MIXED = 5,
+    WLAN_SECURITY_EAP_TLS = 6,
+    WLAN_SECURITY_WILDCARD = 7,
+}; // :664:6
+
+/* ======== components/bl602/bl602_wifi/plf/refip/src/arch/rv32i/arch_main.c ======== */
+
+int dbg_assert_block; // :54:5
+
+void assert_rec(const char *condition, const char *file, int line); // :66:6
+void assert_err(const char *condition, const char *file, int line); // :132:6
+void assert_warn(const char *condition, const char *file, int line); // :163:6
+void force_trigger(const char *msg); // :178:6
+void wifi_main(void *param); // :355:6
+void coex_dump_pta(void); // :527:6
+void coex_dump_wifi(void); // :640:6
+void coex_wifi_rf_forece_enable(int enable); // :650:6
+void coex_wifi_pti_forece_enable(int enable); // :659:6
+
+uint32_t pds_slept_time; // :684:10
+uint32_t pds_woken_time; // :685:10
+
+void coex_wifi_pta_forece_enable(int enable); // :687:6
+
+/* ======== components/bl602/bl602_wifi/plf/refip/src/driver/dma/dma.h ======== */
+
+struct dma_desc {
+    uint32_t src;
+    uint32_t dest;
+    uint16_t length;
+    uint16_t ctrl;
+    uint32_t next;
+}; // :120:8
+
+struct dma_env_tag {
+    volatile struct dma_desc *last_dma[4];
+}; // :137:8
+
+/* ======== components/bl602/bl602_wifi/plf/refip/src/driver/intc/rv32i/intc.c ======== */
+
+void intc_spurious(void); // :51:6
+
+typedef void (*void_fn)(void); // :58:16
+
+static const void_fn intc_irq_handlers[64]; // :61:22
+
+static void intc_enable_irq(int index); // :113:13
+void intc_init(void); // :121:6
+void mac_irq(void); // :150:6
+void bl_irq_handler(void); // :165:6
+
+/* ======== components/bl602/bl602_wifi/plf/refip/src/driver/ipc/ipc_emb.c ======== */
+
+int internel_cal_size_tx_desc; // :59:5
+static TaskHandle_t xTaskToNotify; // :91:21
+uint32_t ipc_emb_counter; // :92:10
+const uint32_t ipc_emb_evt_bit[5]; // :98:16
+struct ipc_emb_env_tag ipc_emb_env; // :110:24
+const int nx_txdesc_cnt_msk[]; // :113:11
+
+void ipc_emb_msg_dma_int_handler(void); // :565:6
+void ipc_emb_dbg_dma_int_handler(void); // :583:6
+void ipc_emb_dump(void); // :593:6
+
+/* ======== components/bl602/bl602_wifi/plf/refip/src/driver/ipc/ipc_emb.h ======== */
+
+struct ipc_emb_env_tag {
+    struct co_list rx_queue;
+    struct co_list cfm_queue;
+    uint8_t ipc_rxdesc_idx;
+    uint8_t ipc_rxbuf_idx;
+    uint8_t ipc_radar_buf_idx;
+    uint8_t ipc_msge2a_buf_idx;
+    uint8_t ipc_dbg_buf_idx;
+    uint8_t ipc_msgacke2a_cnt;
+    uint32_t txdesc_idx;
+    volatile struct txdesc_host *txdesc;
+}; // :41:8
+
+struct ipc_emb_env_tag ipc_emb_env; // :71:31
+const int nx_txdesc_cnt_msk[]; // :75:18
+
+/* ======== components/bl602/bl602_wifi/plf/refip/src/driver/ipc/ipc_shared.c ======== */
+
+struct ipc_shared_env_tag ipc_shared_env; // :24:27
+
+/* ======== components/bl602/bl602_wifi/plf/refip/src/driver/ipc/ipc_shared.h ======== */
+
+struct ipc_a2e_msg {
+    uint32_t dummy_word;
+    uint32_t msg[127];
+}; // :213:8
+
+struct ipc_shared_env_tag {
+    volatile struct ipc_a2e_msg msg_a2e_buf;
+    volatile uint32_t pattern_addr;
+    volatile struct txdesc_host volatile txdesc0[4];
+}; // :244:8
+
+struct ipc_shared_env_tag ipc_shared_env; // :257:34
+
+/* ======== components/bl602/bl602_wifi/plf/refip/src/driver/la/la_mem.h ======== */
+
+struct la_mem_format {
+    uint32_t word[4];
+}; // :37:8
+
+/* ======== components/bl602/bl602_wifi/plf/refip/src/driver/phy/bl602_phy_rf/agcmem_bl602.c ======== */
+
+const uint32_t agcmem[512]; // :3:16
+
+/* ======== components/bl602/bl602_wifi/plf/refip/src/driver/phy/bl602_phy_rf/phy_adapt.c ======== */
+
+typedef struct {
+    int8_t rssi;
+    int8_t lna;
+    float ppm;
+    uint8_t new;
+} input_t; // :53:3
+
+typedef struct {
+    uint8_t used;
+    uint32_t vif_tag;
+    input_t input_buffer[8];
+    int8_t input_buffer_ptr;
+    uint32_t last_update;
+    int8_t rss;
+    int8_t rss_acq;
+    int8_t rss_trk;
+    int8_t rss_state;
+    uint8_t rss_hit_count;
+    uint32_t rss_count;
+    int8_t ris;
+    float ce;
+    int8_t ce_in;
+    int8_t ce_acq;
+    int8_t ce_trk;
+    int8_t ce_state;
+    int8_t ce_num_up_cmds;
+    int8_t ce_num_dn_cmds;
+} pa_state_t; // :83:3
+
+typedef struct {
+    uint32_t leg_length:12;
+    uint32_t leg_rate:4;
+    uint32_t ht_length:16;
+    uint32_t _ht_length:4;
+    uint32_t short_gi:1;
+    uint32_t stbc:2;
+    uint32_t smoothing:1;
+    uint32_t mcs:7;
+    uint32_t pre_type:1;
+    uint32_t format_mod:3;
+    uint32_t ch_bw:2;
+    uint32_t n_sts:3;
+    uint32_t lsig_valid:1;
+    uint32_t sounding:1;
+    uint32_t num_extn_ss:2;
+    uint32_t aggregation:1;
+    uint32_t fec_coding:1;
+    uint32_t dyn_bw:1;
+    uint32_t doze_not_allowed:1;
+    uint32_t antenna_set:8;
+    uint32_t partial_aid:9;
+    uint32_t group_id:6;
+    uint32_t reserved_1c:1;
+    int32_t rssi1:8;
+    int32_t rssi2:8;
+    int32_t agc_lna:4;
+    int32_t agc_rbb1:5;
+    int32_t agc_dg:7;
+    uint32_t reserved_1d:8;
+    uint32_t rcpi:8;
+    uint32_t evm1:8;
+    uint32_t evm2:8;
+    uint32_t freqoff_lo:8;
+    uint32_t freqoff_hi:8;
+    uint32_t reserved2b_1:8;
+    uint32_t reserved2b_2:8;
+    uint32_t reserved2b_3:8;
+} rvec_t; // :134:3
+
+static pa_state_t pa_env[4]; // :136:19
+
+void pa_init(void); // :138:6
+int8_t pa_alloc(uint32_t vif_addr); // :161:8
+void pa_free(uint8_t id); // :175:6
+void pa_reset(uint8_t id); // :185:6
+void pa_input(uint8_t id, struct rx_hd *rhd); // :225:6
+void pa_adapt(uint8_t id); // :247:6
+
+/* ======== components/bl602/bl602_wifi/plf/refip/src/driver/phy/bl602_phy_rf/phy_bl602.c ======== */
+
+struct phy_bl602_cfg_tag {
+    uint32_t reserved;
+}; // :48:8
+
+struct phy_env_tag {
+    struct phy_bl602_cfg_tag cfg;
+    uint16_t chnl_prim20_freq;
+    uint16_t chnl_center1_freq;
+    uint16_t chnl_center2_freq;
+    uint8_t band;
+    uint8_t chnl_type;
+}; // :54:8
+
+struct phy_env_tag phy_env[1]; // :75:20
+static int8_t rxgain_offset_vs_temperature; // :79:15
+static int8_t poweroffset[14]; // :80:15
+
+void phy_mdm_isr(void); // :711:6
+void phy_rc_isr(void); // :716:6
+
+/* ======== components/bl602/bl602_wifi/plf/refip/src/driver/phy/bl602_phy_rf/phy_hal.c ======== */
+
+struct phy_hal_tag {
+    int16_t temperature;
+    uint8_t capcode;
+}; // :6:8
+
+static struct phy_hal_tag hal_env; // :15:27
+
+uint8_t hal_get_capcode(void); // :43:9
+void hal_set_capcode(uint32_t capcode); // :48:6
+void hal_set_capcode_asymm(uint32_t capcode_in, uint32_t capcode_out); // :55:6
+void hal_get_capcode_asymm(uint8_t *capcode_in, uint8_t *capcode_out); // :64:6
+bool hal_get_temperature(int16_t *temperature); // :75:5
+void hal_set_temperature(int16_t temperature); // :83:6
+
+/* ======== components/bl602/bl602_wifi/plf/refip/src/driver/phy/bl602_phy_rf/phy_helper.c ======== */
+
+static char *rc_state_str[8]; // :35:14
+static char *rf_state_str[8]; // :47:14
+
+struct HWStateMachineReg {
+    uint32_t rxControl:6;
+    uint32_t reserved_7_6:2;
+    uint32_t txControl:9;
+    uint32_t reserved_23_17:7;
+    uint32_t macControl:8;
+}; // :59:8
+
+struct dump_data_t {
+    uint32_t time;
+    const char *func_name;
+    uint32_t rc_state;
+    uint32_t rf_state;
+    uint32_t mac_debugRegHWSM1;
+    uint32_t mac_debugRegHWSM2;
+    uint16_t mac_debugPortCoex;
+    uint16_t mac_debugPortBackoff;
+    uint16_t mac_debugPortMacPhyIf;
+    uint16_t mac_debugPortMacPhyIf2;
+    uint16_t phy_debugPortMainFSM;
+    uint16_t phy_debugPortTDTX;
+    uint16_t phy_debugPortDSSSCCK1;
+    uint16_t phy_debugPortDSSSCCKTx;
+}; // :68:8
+
+static struct dump_data_t dump_data_poll[18]; // :86:27
+static uint8_t dump_data_ptr; // :87:16
+
+typedef long long (*timer_func_ptr)(...); // :237:21
+
+void helper_channel_monitor(uint32_t chanfreq, timer_func_ptr timer_func, int nrepeats, int mon_time_ms); // :378:6
+
+/* ======== components/bl602/bl602_wifi/plf/refip/src/driver/phy/bl602_phy_rf/phy_tcal.c ======== */
+
+struct tcal_tag {
+    int16_t prev_temperature;
+    uint32_t last_action_time[4];
+    uint32_t last_action_temperature[4];
+    int32_t last_action_out[4];
+    bool enabled;
+}; // :29:8
+
+static struct tcal_tag tcal_env; // :41:24
+
+void phy_tcal_stop(void); // :69:6
+void phy_tcal_handle(void); // :74:6
+void phy_tcal_callback(int16_t temperature); // :104:6
+void phy_tcal_txpwr(int16_t curr_temperature); // :141:6
+
+/* ======== components/bl602/bl602_wifi/plf/refip/src/driver/phy/bl602_phy_rf/phy_trpc.c ======== */
+
+static int8_t txpwr_vs_rate_table[3]; // :12:15
+struct trpc_env_tag trpc_env; // :49:21
+
+int8_t trpc_get_rf_min_power(void); // :120:8
+uint8_t trpc_get_default_power_idx(uint8_t formatmod, uint8_t mcs); // :125:9
+uint8_t trpc_get_power_idx(uint8_t formatmod, uint8_t mcs, int8_t pwr_dbm); // :134:9
+void trpc_update_vs_channel(int8_t channel_MHz); // :171:6
+void trpc_update_vs_temperature(int8_t temperature); // :178:6
+
+/* ======== components/bl602/bl602_wifi/plf/refip/src/driver/phy/bl602_phy_rf/phy_trpc.h ======== */
+
+struct trpc_env_tag {
+    int8_t power_dbm_max_rf;
+    int8_t power_dbm_min_rf;
+    int8_t power_dbm_lim_reg;
+    int16_t channel_freq;
+    int8_t temperature;
+    int8_t temperature_compensate;
+}; // :13:8
+
+struct trpc_env_tag trpc_env; // :33:28
+
+/* ======== components/bl602/bl602_wifi/plf/refip/src/driver/phy/bl602_phy_rf/rf/Inc/bl602_rf_calib_data.h ======== */
+
+typedef struct {
+    uint32_t gpadc_oscode:12;
+    uint32_t rx_offset_i:10;
+    uint32_t rx_offset_q:10;
+    uint32_t rbb_cap1_fc_i:6;
+    uint32_t rbb_cap1_fc_q:6;
+    uint32_t rbb_cap2_fc_i:6;
+    uint32_t rbb_cap2_fc_q:6;
+    uint32_t tx_dc_comp_i:12;
+    uint32_t tx_dc_comp_q:12;
+    uint32_t tmx_cs:3;
+    uint32_t txpwr_att_rec:3;
+    uint32_t pa_pwrmx_osdac:4;
+    uint32_t tmx_csh:3;
+    uint32_t tmx_csl:3;
+    uint32_t tsen_refcode_rfcal:12;
+    uint32_t tsen_refcode_corner:12;
+    uint32_t rc32k_code_fr_ext:10;
+    uint32_t rc32m_code_fr_ext:8;
+    uint32_t saradc_oscode:10;
+    uint16_t fcal_4osmx:4;
+} rf_calib1_tag; // :37:3
+
+typedef struct {
+    uint16_t fcal:8;
+    uint16_t acal:5;
+} rf_calib2_tag; // :44:3
+
+typedef struct {
+    uint32_t rosdac_i:6;
+    uint32_t rosdac_q:6;
+    uint32_t rx_iq_gain_comp:11;
+    uint32_t rx_iq_phase_comp:10;
+} rf_calib3_tag; // :53:3
+
+typedef struct {
+    uint32_t tosdac_i:6;
+    uint32_t tosdac_q:6;
+    uint32_t tx_iq_gain_comp:11;
+    uint32_t tx_iq_phase_comp:10;
+} rf_calib4_tag; // :62:3
+
+typedef volatile struct {
+    uint32_t inited;
+    rf_calib1_tag cal;
+    rf_calib2_tag lo[21];
+    rf_calib3_tag rxcal[4];
+    rf_calib4_tag txcal[8];
+} rf_calib_data_tag; // :72:3
+
+rf_calib_data_tag *rf_calib_data; // :75:27
+
+/* ======== components/bl602/bl602_wifi/plf/refip/src/driver/phy/bl602_phy_rf/rf/Inc/bl602_rf_private.h ======== */
+
+typedef volatile struct {
+    uint32_t index;
+    int32_t dvga;
+} tx_pwr_index; // :61:3
+
+tx_pwr_index *tp_index; // :62:22
+
+typedef volatile struct {
+    uint32_t notch_en;
+    int32_t spur_freq;
+} notch_param; // :67:3
+
+typedef volatile struct {
+    uint32_t vbcore;
+    uint32_t iet;
+    uint32_t vbcore_11n;
+    uint32_t iet_11n;
+    uint32_t vbcore_11g;
+    uint32_t iet_11g;
+    uint32_t vbcore_11b;
+    uint32_t iet_11b;
+    uint32_t lo_fbdv_halfstep_en;
+    uint32_t lo_fbdv_halfstep_en_tx;
+    uint32_t lo_fbdv_halfstep_en_rx;
+    uint32_t clkpll_reset_postdiv;
+    uint32_t clkpll_dither_sel;
+} regs_to_opti; // :84:3
+
+regs_to_opti *opti_regs; // :85:22
+
+/* ======== components/bl602/bl602_wifi/plf/refip/src/driver/phy/bl602_phy_rf/rf/Src/bl602_calib_data.c ======== */
+
+static rf_calib_data_tag data; // :9:26
+rf_calib_data_tag *rf_calib_data; // :10:20
+
+void rf_pri_init_calib_mem(void); // :14:6
+
+/* ======== components/bl602/bl602_wifi/plf/refip/src/driver/phy/bl602_phy_rf/rf/Src/bl602_rf_private.c ======== */
+
+static uint32_t state_rf_fsm_ctrl_hw; // :121:17
+static uint32_t state_rfctrl_hw_en; // :122:17
+static uint32_t state_rfcal_ctrlen; // :123:17
+static uint32_t state_pucr1; // :124:17
+static uint32_t state_fbdv; // :125:17
+static uint32_t state_sdm1; // :126:17
+static uint32_t state_sdm2; // :127:17
+static uint32_t state_rbb3; // :128:17
+static uint32_t state_adda1; // :129:17
+static uint32_t state_dfe_ctrl_0; // :130:17
+static uint32_t state_dfe_ctrl_3; // :131:17
+static uint32_t state_dfe_ctrl_6; // :132:17
+static uint32_t state_dfe_ctrl_7; // :133:17
+static uint32_t state_trx_gain1; // :134:17
+static uint32_t state_singen_ctrl0; // :135:17
+static uint32_t state_singen_ctrl2; // :136:17
+static uint32_t state_singen_ctrl3; // :137:17
+static uint32_t state_sram_ctrl0; // :138:17
+static uint32_t state_sram_ctrl1; // :139:17
+static uint32_t state_sram_ctrl2; // :140:17
+static uint32_t state_rf_resv_reg_1; // :141:17
+static uint32_t state_pa1; // :142:17
+static uint32_t state_ten_ac; // :143:17
+static uint32_t state_rfif_dfe_ctrl0; // :144:17
+static uint32_t state_tbb; // :145:17
+static uint32_t state_vco2; // :146:17
+static uint32_t init_fast; // :148:17
+static int32_t temps[13]; // :150:16
+static uint32_t Tchannels[6]; // :153:17
+static int32_t Tchannel_os[6]; // :154:16
+static int32_t Tchannel_os_low[6]; // :155:16
+static int32_t index_os_pre; // :160:16
+static int32_t index_os_pre_mdb; // :161:16
+static int32_t dvga_os_pre; // :162:16
+static int32_t up_dn; // :163:16
+static int32_t Tthr; // :164:16
+static int8_t temps_dvga[16]; // :165:15
+static uint32_t channel_div_table[21]; // :184:17
+static uint16_t channel_cnt_table[21]; // :310:17
+static uint16_t channel_cnt_range[3]; // :430:17
+static uint16_t fcal_div; // :438:17
+static uint16_t tmxcss[3]; // :440:17
+static int32_t rx_notch_para_40M[14]; // :446:16
+static tx_pwr_index data; // :463:21
+tx_pwr_index *tp_index; // :464:15
+static int32_t tx_pwr_table_a0[16]; // :465:16
+static int32_t tx_pwr_table_a1[16]; // :485:16
+static int32_t tx_pwr_table[16]; // :519:16
+static int32_t tx_pwr_table_origin[16]; // :520:16
+static int32_t tx_pwr_os; // :522:16
+static int32_t tx_pwr_os_temperature; // :523:16
+static int32_t tx_pwr_ch_os_a0[14]; // :524:16
+static int32_t tx_pwr_ch_os_a1[14]; // :556:16
+static int32_t tx_pwr_ch_os[14]; // :572:16
+static uint32_t txcal_para_a0[8]; // :574:17
+static uint32_t txcal_para_a1[8]; // :608:17
+static uint32_t txcal_para[8]; // :618:17
+static regs_to_opti opti_regs_data; // :620:21
+regs_to_opti *opti_regs; // :621:15
+static uint16_t channel_cw_table[21]; // :623:17
+static uint16_t channel_cnt_opt_table[40]; // :624:17
+
+static void rf_pri_restore_state_for_cal(void); // :2049:13
+static void rf_pri_singen_start(void); // :2093:13
+static uint32_t rf_pri_pm_pwr(void); // :2115:17
+static void rf_pri_rccal_config(uint32_t iq, uint32_t rbb_fc); // :2151:13
+static void rf_pri_start_txdfe(void); // :2253:13
+static int32_t rf_pri_pm_pwr_avg(uint32_t iq, uint32_t acc_len); // :2307:16
+static void rf_pri_txcal_config(uint32_t param_ind, int32_t val); // :2347:13
+static int32_t rf_pri_txcal_search_core(uint32_t param_ind, uint32_t center, uint32_t delta, uint32_t meas_freq); // :2373:16
+static void rf_pri_txcal_config_hw(void); // :2437:13
+static uint32_t rf_pri_rccal_iq(uint32_t iq); // :2540:17
+static uint16_t rf_pri_fcal_meas(uint32_t cw); // :2644:17
+void rf_pri_config_bandwidth(uint32_t bw); // :2739:6
+void rf_pri_txcal(void); // :2748:6
+void rf_pri_roscal(void); // :2931:6
+void rf_pri_rccal(void); // :3097:6
+void rf_pri_lo_acal(void); // :3186:6
+void rf_pri_fcal(void); // :3259:6
+void rf_pri_full_cal(void); // :3429:6
+void rf_pri_restore_cal_reg(void); // :3468:6
+void rf_pri_update_power_offset(int32_t *power_offset); // :3503:6
+
+/* ======== components/bl602/bl602_wifi/plf/refip/src/driver/phy/bl602_phy_rf/rfc_bl602.c ======== */
+
+static uint8_t inited; // :21:16
+static double xtalfreq_MHz; // :23:15
+
+void rfc_reset(void); // :1040:6
+void rfc_ver_set(uint8_t ver); // :1047:6
+void rfc_txdfe_start(void); // :1056:6
+void rfc_txdfe_stop(void); // :1063:6
+void rfc_txdfe_mux(int8_t signal_source); // :1070:6
+void rfc_txdfe_set_dvga(int8_t dvga_qdb); // :1075:6
+void rfc_txdfe_set_iqgaincomp(uint8_t en, uint16_t coeff); // :1084:6
+void rfc_txdfe_set_iqphasecomp(uint8_t en, int16_t coeff); // :1090:6
+void rfc_txdfe_set_dccomp(int16_t dcc_i, int16_t dcc_q); // :1097:6
+void rfc_txdfe_set_iqswap(uint8_t swap_on); // :1103:6
+void rfc_rxdfe_start(void); // :1113:6
+void rfc_rxdfe_stop(void); // :1119:6
+void rfc_rxdfe_set_iqgaincomp(uint8_t en, uint16_t coeff); // :1125:6
+void rfc_rxdfe_set_iqphasecomp(uint8_t en, int16_t coeff); // :1131:6
+void rfc_rxdfe_set_dccomp(int16_t dcc_i, int16_t dcc_q); // :1137:6
+void rfc_rxdfe_set_iqswap(uint8_t swap_on); // :1143:6
+void rfc_rxdfe_set_notch0(uint8_t en, uint8_t alpha, int8_t nrmfc); // :1148:6
+void rfc_rxdfe_set_notch1(uint8_t en, uint8_t alpha, int8_t nrmfc); // :1155:6
+void rfc_sg_start(uint32_t inc_step, uint32_t gain_i, uint32_t gain_q, uint32_t addr_i, uint32_t addr_q); // :1167:6
+void rfc_sg_stop(void); // :1193:6
+uint32_t rfc_pm_start(uint32_t insel, int32_t freq_cw, uint32_t acclen, uint32_t rshift, int32_t *raw_acc_i, int32_t *raw_acc_q); // :1205:10
+void rfc_pm_stop(void); // :1272:6
+void rfc_hwctrl_txrfgain(uint8_t hwctrl_on); // :1282:6
+void rfc_hwctrl_rxgain(uint8_t hwctrl_on); // :1287:6
+void rfc_hwctrl_txdvga(uint8_t hwctrl_on); // :1292:6
+void rfc_hwctrl_calparam(uint8_t hwctrl_on); // :1297:6
+void rfc_fsm_force(uint8_t state); // :1302:6
+void rfc_rc_fsm_force(uint8_t state); // :1313:6
+void rfc_coex_force_to(uint32_t force_enable, uint32_t bbmode); // :1327:6
+void rfc_config_power(uint32_t mode, uint32_t tbb_boost, uint32_t tbb, uint32_t tmx); // :1346:6
+bool rfc_config_power_ble(int32_t pwr_dbm); // :1355:5
+void rfc_config_bandwidth(uint32_t mode); // :1447:6
+uint32_t rfc_get_power_level(uint32_t formatmod, int32_t power); // :1479:10
+void rfc_wlan_mode_force(uint32_t force_mode); // :1500:6
+void rfc_apply_tx_dvga_offset(int8_t offset_qdb); // :1519:6
+void rfc_apply_tx_dvga(int8_t *dvga_qdb); // :1540:6
+void rfc_dump(void); // :1560:6
+void rfc_apply_tx_power_offset(uint8_t channel, int8_t *power_offset); // :1643:6
+
+/* ======== components/bl602/bl602_wifi/plf/refip/src/driver/phy/bl602_phy_rf/rfc_bl602.h ======== */
+
+struct rfc_status_tag {
+    uint32_t pkdet_out_raw:1;
+    uint32_t dig_xtal_clk_dbg:1;
+    uint32_t clk_ble_16m_dbg:1;
+    uint32_t clk_rc_dbg0:1;
+    uint32_t clk_adcpow_dbg:1;
+    uint32_t clk_fetx_dbg:1;
+    uint32_t clk_ferx_dbg:1;
+    uint32_t clkpll_postdiv_outclk_dbg:1;
+    uint32_t clk_soc_480m_dbg:1;
+    uint32_t clk_soc_240m_dbg:1;
+    uint32_t clk_soc_192m_dbg:1;
+    uint32_t clk_soc_160m_dbg:1;
+    uint32_t clk_soc_120m_dbg:1;
+    uint32_t clk_soc_96m_dbg:1;
+    uint32_t clk_soc_80m_dbg:1;
+    uint32_t clk_soc_48m_dbg:1;
+    uint32_t clk_soc_32m_dbg:1;
+    uint32_t pad_pkdet_out:1;
+    uint32_t pad_agc_ctrl:10;
+    uint32_t rf_pkdet_rst_hw:1;
+    uint32_t rf_cbw_wifi:2;
+    uint32_t lo_unlocked:1;
+    uint32_t fsm_pu_txbuf:1;
+    uint32_t fsm_pu_rxbuf:1;
+    uint32_t fsm_pu_tosdac:1;
+    uint32_t fsm_pu_dac:1;
+    uint32_t fsm_trsw_en:1;
+    uint32_t fsm_pu_adc:1;
+    uint32_t fsm_pu_pkdet:1;
+    uint32_t fsm_pu_rbb:1;
+    uint32_t fsm_pu_rmx:1;
+    uint32_t fsm_pu_rmxgm:1;
+    uint32_t fsm_pu_lna:1;
+    uint32_t clk_rc_dbg2:1;
+    uint32_t rf_lna_ind_hw:4;
+    uint32_t rf_rbb_ind_hw:4;
+    uint32_t rf_tx_pow_lvl_hw:4;
+    uint32_t rf_rc_lo_rdy:1;
+    uint32_t rf_fsm_state:3;
+    uint32_t rf_rc_state:3;
+    uint32_t clk_rc_dbg:1;
+}; // :84:8
+
+/* ======== components/bl602/bl602_wifi/plf/refip/src/driver/phy/phy.h ======== */
+
+struct phy_channel_info {
+    uint32_t info1;
+    uint32_t info2;
+}; // :97:8
+
+struct phy_cfg_tag {
+    uint32_t parameters[16];
+}; // :113:8
+
+/* ======== components/bl602/bl602_wifi/plf/refip/src/driver/phy/rf.c ======== */
+
+void rf_clkpll_isr(void); // :45:6
+
+/* ======== components/bl602/bl602_wifi/plf/refip/src/driver/phyif/phyif_utils.c ======== */
+
+typedef struct {
+    uint32_t leg_length:12;
+    uint32_t leg_rate:4;
+    uint32_t ht_length:16;
+    uint32_t _ht_length:4;
+    uint32_t short_gi:1;
+    uint32_t stbc:2;
+    uint32_t smoothing:1;
+    uint32_t mcs:7;
+    uint32_t pre_type:1;
+    uint32_t format_mod:3;
+    uint32_t ch_bw:2;
+    uint32_t n_sts:3;
+    uint32_t lsig_valid:1;
+    uint32_t sounding:1;
+    uint32_t num_extn_ss:2;
+    uint32_t aggregation:1;
+    uint32_t fec_coding:1;
+    uint32_t dyn_bw:1;
+    uint32_t doze_not_allowed:1;
+    uint32_t antenna_set:8;
+    uint32_t partial_aid:9;
+    uint32_t group_id:6;
+    uint32_t reserved_1c:1;
+    int32_t rssi1:8;
+    int32_t rssi2:8;
+    int32_t rssi3:8;
+    int32_t rssi4:8;
+    uint32_t reserved_1d:8;
+    uint32_t rcpi:8;
+    uint32_t evm1:8;
+    uint32_t evm2:8;
+    uint32_t evm3:8;
+    uint32_t evm4:8;
+    uint32_t reserved2b_1:8;
+    uint32_t reserved2b_2:8;
+    uint32_t reserved2b_3:8;
+} phyif_utils_recvtable_priv_t; // :47:3
+
+int phyif_utils_decode(phyif_utils_recvtable_t *vec, int8_t *ppm); // :49:5
+
+/* ======== components/bl602/bl602_wifi/plf/refip/src/driver/phyif/phyif_utils.h ======== */
+
+typedef struct {
+    uint32_t recvtable1;
+    uint32_t recvtable2;
+    uint32_t recvtable3;
+    uint32_t recvtable4;
+    uint32_t recvtable5;
+    uint32_t recvtable6;
+} phyif_utils_recvtable_t; // :11:3
+
+/* ======== components/bl602/bl602_wifi/plf/refip/src/driver/sysctrl/sysctrl.c ======== */
+
+void sysctrl_init(void); // :34:6

--- a/dwarf/libblecontroller.h
+++ b/dwarf/libblecontroller.h
@@ -1,0 +1,3620 @@
+/* ======== components/network/ble/blecontroller/ip/ble/ll/src/em/em_buf.c ======== */
+
+struct em_buf_env_tag em_buf_env; // :67:23
+
+void em_buf_init(void); // :83:6
+void em_buf_rx_free(uint8_t hdl); // :182:6
+uint8_t *em_buf_rx_buff_addr_get(uint16_t rx_hdl); // :188:10
+uint8_t *em_buf_tx_buff_addr_get(struct em_buf_tx_desc *tx_desc); // :193:10
+bool em_buf_tx_free(struct em_desc_node *desc_to_be_freed); // :198:5
+
+/* ======== components/network/ble/blecontroller/ip/ble/ll/src/em/em_buf.h ======== */
+
+struct em_buf_node {
+    struct co_list_hdr hdr;
+    uint16_t idx;
+    uint16_t buf_ptr;
+}; // :54:8
+
+struct em_desc_node {
+    struct co_list_hdr hdr;
+    uint16_t idx;
+    uint16_t buffer_idx;
+    uint16_t buffer_ptr;
+    uint8_t llid;
+    uint8_t length;
+}; // :63:8
+
+struct em_buf_tx_desc {
+    uint16_t txptr;
+    uint16_t txheader;
+    uint16_t txdataptr;
+    uint16_t txdle;
+}; // :79:8
+
+struct em_buf_env_tag {
+    struct co_list tx_desc_free;
+    struct co_list tx_buff_free;
+    struct em_desc_node tx_desc_node[26];
+    struct em_buf_node tx_buff_node[2];
+    struct em_buf_tx_desc *tx_desc;
+    uint8_t rx_current;
+}; // :92:8
+
+struct em_buf_env_tag em_buf_env; // :116:30
+
+/* ======== components/network/ble/blecontroller/ip/ble/ll/src/llc/llc.c ======== */
+
+struct llc_env_tag *llc_env[2]; // :66:21
+static const struct ke_task_desc TASK_DESC_LLC; // :69:34
+
+void llc_init(void); // :76:6
+void llc_reset(void); // :94:6
+void llc_start(struct llc_create_con_req_ind *param, struct ea_elt_tag *elt); // :109:6
+void llc_stop(uint16_t conhdl); // :282:6
+void llc_discon_event_complete_send(ke_task_id_t src_id, uint8_t status, uint8_t conhdl, uint8_t reason); // :313:6
+void llc_le_con_cmp_evt_send(uint8_t status, uint16_t conhdl, struct llc_create_con_req_ind *param); // :330:6
+void llc_le_ch_sel_algo_evt_send(uint8_t chSel, uint16_t conhdl, struct llc_create_con_req_ind *param); // :541:6
+void llc_con_update_complete_send(uint8_t status, uint16_t conhdl, struct lld_evt_tag *evt); // :561:6
+void llc_ltk_req_send(uint16_t conhdl, const struct llcp_enc_req *param); // :605:6
+void llc_feats_rd_event_send(uint8_t status, uint16_t conhdl, const struct le_features *feats); // :621:6
+void llc_version_rd_event_send(uint8_t status, uint16_t conhdl); // :671:6
+void llc_common_cmd_complete_send(uint16_t opcode, uint8_t status, uint16_t conhdl); // :690:6
+void llc_common_cmd_status_send(uint16_t opcode, uint8_t status, uint16_t conhdl); // :701:6
+void llc_common_flush_occurred_send(uint16_t conhdl); // :711:6
+void llc_common_enc_key_ref_comp_evt_send(uint16_t conhdl, uint8_t status); // :719:6
+void llc_common_enc_change_evt_send(uint16_t conhdl, uint8_t enc_status, uint8_t status); // :728:6
+void llc_common_nb_of_pkt_comp_evt_send(uint16_t conhdl, uint8_t nb_of_pkt); // :753:6
+void llc_con_update_ind(uint16_t conhdl, struct ea_elt_tag *elt_new); // :767:6
+void llc_lsto_con_update(uint16_t conhdl); // :800:6
+void llc_map_update_ind(uint16_t conhdl); // :817:6
+void llc_con_update_finished(uint16_t conhdl); // :832:6
+void llc_map_update_finished(uint16_t conhdl); // :869:6
+
+/* ======== components/network/ble/blecontroller/ip/ble/ll/src/llc/llc.h ======== */
+
+enum llc_status_flag {
+    LLC_STAT_INSTANT_PROCEED_MASK = 2048,
+    LLC_STAT_INSTANT_PROCEED_LSB = 11,
+    LLC_STAT_LLCP_INSTANT_EXTRACTED_MASK = 1024,
+    LLC_STAT_LLCP_INSTANT_EXTRACTED_LSB = 10,
+    LLC_STAT_DISC_REM_REQ_MASK = 512,
+    LLC_STAT_DISC_REM_REQ_LSB = 9,
+    LLC_STAT_SYNC_FOUND_MASK = 256,
+    LLC_STAT_SYNC_FOUND_LSB = 8,
+    LLC_STAT_UPDATE_EVT_SENT_MASK = 128,
+    LLC_STAT_UPDATE_EVT_SENT_LSB = 7,
+    LLC_STAT_UPDATE_HOST_REQ_MASK = 64,
+    LLC_STAT_UPDATE_HOST_REQ_LSB = 6,
+    LLC_STAT_UPDATE_PENDING_MASK = 32,
+    LLC_STAT_UPDATE_PENDING_LSB = 5,
+    LLC_STAT_TO_PENDING_MASK = 16,
+    LLC_STAT_TO_PENDING_LSB = 4,
+    LLC_STAT_LLCP_DISCARD_MASK = 8,
+    LLC_STAT_LLCP_DISCARD_LSB = 3,
+    LLC_STAT_WAIT_TRAFFIC_PAUSED_MASK = 4,
+    LLC_STAT_WAIT_TRAFFIC_PAUSED_LSB = 2,
+    LLC_STAT_PEER_VERS_KNOWN_MASK = 2,
+    LLC_STAT_PEER_VERS_KNOWN_LSB = 1,
+    LLC_STAT_FEAT_EXCH_MASK = 1,
+    LLC_STAT_FEAT_EXCH_LSB = 0,
+}; // :65:6
+
+enum llc_dle_flag {
+    LLC_DLE_EVT_SENT_MASK = 2,
+    LLC_DLE_EVT_SENT_LSB = 1,
+    LLC_DLE_REQ_RCVD_MASK = 1,
+    LLC_DLE_REQ_RCVD_LSB = 0,
+}; // :122:6
+
+struct rem_version {
+    uint8_t vers;
+    uint16_t compid;
+    uint16_t subvers;
+}; // :185:8
+
+struct encrypt {
+    struct sess_k_div skd;
+    struct ltk ltk;
+    uint8_t randn[16];
+}; // :196:8
+
+struct data_len_ext_tag {
+    uint16_t conn_max_tx_octets;
+    uint16_t conn_max_rx_octets;
+    uint16_t conn_eff_max_tx_octets;
+    uint16_t conn_eff_max_rx_octets;
+    uint16_t conn_max_tx_time;
+    uint16_t conn_max_rx_time;
+    uint16_t conn_eff_max_tx_time;
+    uint16_t conn_eff_max_rx_time;
+    bool send_req_not_allowed;
+    uint8_t data_len_ext_flag;
+}; // :207:8
+
+struct llc_env_tag {
+    void *operation[4];
+    struct ea_elt_tag *elt;
+    struct llc_ch_asses_tag chnl_assess;
+    struct rem_version peer_version;
+    struct data_len_ext_tag data_len_ext_info;
+    uint16_t sup_to;
+    uint16_t n_sup_to;
+    uint16_t auth_payl_to;
+    uint16_t auth_payl_to_margin;
+    uint16_t llc_status;
+    struct le_chnl_map ch_map;
+    struct le_chnl_map n_ch_map;
+    int8_t rssi;
+    struct le_features feats_used;
+    struct encrypt encrypt;
+    uint8_t disc_reason;
+    bool disc_event_sent;
+    uint8_t loc_proc_state;
+    uint8_t rem_proc_state;
+    uint8_t encryption_state;
+    bool peer_sup_conn_param_req;
+}; // :269:8
+
+struct llc_env_tag *llc_env[2]; // :368:28
+
+/* ======== components/network/ble/blecontroller/ip/ble/ll/src/llc/llc_ch_asses.c ======== */
+
+void llc_ch_assess_local(uint16_t conhdl, uint16_t status, int8_t rssi, uint8_t channel); // :58:6
+uint8_t llc_ch_assess_get_local_ch_map(uint16_t conhdl, struct le_chnl_map *map, struct le_chnl_map *hostmap); // :108:9
+struct le_chnl_map *llc_ch_assess_get_current_ch_map(uint16_t conhdl); // :132:22
+void llc_ch_assess_reass_ch(uint16_t conhdl, struct le_chnl_map *map, struct le_chnl_map *hostmap, uint8_t nb_chgood); // :139:6
+
+/* ======== components/network/ble/blecontroller/ip/ble/ll/src/llc/llc_ch_asses.h ======== */
+
+enum lld_ch_asses_ponderation {
+    LLD_CH_ASSES_SYNC_ERR_HIGH_RSSI = -3,
+    LLD_CH_ASSES_CRC_ERR = -3,
+    LLD_CH_ASSES_SYNC_ERR_LOW_RSSI_NO_LATENCY = -1,
+    LLD_CH_ASSES_SYNC_ERR_LOW_RSSI_LATENCY = 0,
+    LLD_CH_ASSES_SYNC_FOUND_NO_CRC_ERR = 3,
+}; // :59:6
+
+struct llc_ch_asses_tag {
+    int8_t rcvd_quality[37];
+    bool latency_en;
+    uint8_t reassess_count;
+    uint8_t reassess_cursor;
+}; // :80:8
+
+/* ======== components/network/ble/blecontroller/ip/ble/ll/src/llc/llc_hci.c ======== */
+
+static int hci_le_con_update_cmd_handler(const ke_msg_id_t msgid, const struct hci_le_con_update_cmd *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :92:12
+static int hci_le_rd_chnl_map_cmd_handler(const ke_msg_id_t msgid, const struct hci_basic_conhdl_cmd *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :214:12
+static int hci_le_rd_rem_used_feats_cmd_handler(const ke_msg_id_t msgid, const struct hci_le_rd_rem_used_feats_cmd *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :263:12
+static int hci_le_start_enc_cmd_handler(const ke_msg_id_t msgid, const struct hci_le_start_enc_cmd *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :341:12
+static int hci_le_ltk_req_reply_cmd_handler(const ke_msg_id_t msgid, const struct hci_le_ltk_req_reply_cmd *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :436:12
+static int hci_le_ltk_req_neg_reply_cmd_handler(const ke_msg_id_t msgid, const struct hci_basic_conhdl_cmd *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :495:12
+static int hci_le_rem_con_param_req_reply_cmd_handler(const ke_msg_id_t msgid, const struct hci_le_rem_con_param_req_reply_cmd *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :577:12
+static int hci_le_rem_con_param_req_neg_reply_cmd_handler(const ke_msg_id_t msgid, const struct hci_le_rem_con_param_req_neg_reply_cmd *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :661:12
+static int hci_flush_cmd_handler(const ke_msg_id_t msgid, const struct hci_basic_conhdl_cmd *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :725:12
+static int hci_disconnect_cmd_handler(const ke_msg_id_t msgid, const struct hci_disconnect_cmd *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :760:12
+static int hci_rd_rssi_cmd_handler(const ke_msg_id_t msgid, const struct hci_basic_conhdl_cmd *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :816:12
+static int hci_rd_tx_pwr_lvl_cmd_handler(const ke_msg_id_t msgid, const struct hci_rd_tx_pwr_lvl_cmd *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :859:12
+static int hci_rd_rem_ver_info_cmd_handler(const ke_msg_id_t msgid, const struct hci_rd_rem_ver_info_cmd *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :921:12
+static int hci_rd_auth_payl_to_cmd_handler(const ke_msg_id_t msgid, const struct hci_rd_auth_payl_to_cmd *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :982:12
+static int hci_wr_auth_payl_to_cmd_handler(const ke_msg_id_t msgid, const struct hci_wr_auth_payl_to_cmd *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :1025:12
+static int hci_le_set_data_len_cmd_handler(const ke_msg_id_t msgid, const struct hci_le_set_data_len_cmd *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :1234:12
+
+static const struct ke_msg_handler llc_hci_command_handler_tab[16]; // :1408:36
+
+int llc_hci_command_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :1457:5
+int llc_hci_acl_data_tx_handler(const ke_msg_id_t msgid, const struct hci_acl_data_tx *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :1498:5
+
+/* ======== components/network/ble/blecontroller/ip/ble/ll/src/llc/llc_llcp.c ======== */
+
+enum llc_instant_state {
+    LLC_INSTANT_IGNORED = 0,
+    LLC_INSTANT_ACCEPTED = 1,
+    LLC_INSTANT_COLLISION = 2,
+    LLC_INSTANT_PASSED = 3,
+    LLC_INSTANT_MIC_FAILURE = 4,
+    LLC_INSTANT_REJECT = 5,
+}; // :74:6
+
+typedef int (*llcp_pdu_handler_func_t)(uint16_t, ke_task_id_t, bool, union llcp_pdu *); // :98:15
+
+struct llcp_pdu_handler_info {
+    llcp_pdu_handler_func_t handler;
+    bool int_ctx_allowed;
+    uint8_t enc_auth;
+}; // :137:8
+
+static const struct llcp_pdu_handler_info llcp_pdu_handler[22]; // :149:43
+
+void llc_llcp_version_ind_pdu_send(uint16_t conhdl); // :194:6
+void llc_llcp_ch_map_update_pdu_send(uint16_t conhdl); // :213:6
+void llc_llcp_pause_enc_req_pdu_send(uint16_t conhdl); // :232:6
+void llc_llcp_pause_enc_rsp_pdu_send(uint16_t conhdl); // :250:6
+void llc_llcp_enc_req_pdu_send(uint16_t conhdl, struct hci_le_start_enc_cmd *param); // :269:6
+void llc_llcp_enc_rsp_pdu_send(uint16_t conhdl, struct llcp_enc_req *param); // :305:6
+void llc_llcp_start_enc_rsp_pdu_send(uint16_t conhdl); // :331:6
+void llc_llcp_reject_ind_pdu_send(uint16_t conhdl, uint8_t rej_opcode, uint8_t reason); // :355:6
+void llc_llcp_con_update_pdu_send(uint16_t conhdl, struct llcp_con_upd_ind *param); // :397:6
+void llc_llcp_con_param_req_pdu_send(uint16_t conhdl, struct llc_con_upd_req_ind *param); // :419:6
+void llc_llcp_con_param_rsp_pdu_send(uint16_t conhdl, struct llc_con_upd_req_ind *param); // :446:6
+void llc_llcp_feats_req_pdu_send(uint16_t conhdl); // :473:6
+void llc_llcp_feats_rsp_pdu_send(uint16_t conhdl); // :499:6
+void llc_llcp_start_enc_req_pdu_send(uint16_t conhdl); // :518:6
+void llc_llcp_terminate_ind_pdu_send(uint16_t conhdl, uint8_t err_code); // :549:6
+void llc_llcp_unknown_rsp_send_pdu(uint16_t conhdl, uint8_t unk_type); // :596:6
+void llc_llcp_ping_req_pdu_send(uint16_t conhdl); // :612:6
+void llc_llcp_ping_rsp_pdu_send(uint16_t conhdl); // :627:6
+void llc_llcp_length_req_pdu_send(uint16_t conhdl); // :642:6
+void llc_llcp_length_rsp_pdu_send(uint16_t conhdl); // :663:6
+static void llc_llcp_send(uint8_t conhdl, void *param, uint8_t opcode); // :773:13
+static void llc_llcp_reject_ind(uint16_t conhdl, const ke_task_id_t dest_id, uint8_t err_code, bool extended); // :822:13
+int llc_llcp_recv_handler(ke_task_id_t dest_id, uint8_t status, union llcp_pdu *pdu, bool int_ctx); // :1059:5
+static int llcp_con_upd_ind_handler(uint16_t conhdl, ke_task_id_t dest_id, bool int_ctx, struct llcp_con_upd_ind *param); // :1173:12
+static int llcp_channel_map_ind_handler(uint16_t conhdl, ke_task_id_t dest_id, bool int_ctx, struct llcp_channel_map_ind *param); // :1328:12
+static int llcp_terminate_ind_handler(uint16_t conhdl, ke_task_id_t dest_id, bool int_ctx, struct llcp_terminate_ind *param); // :1450:12
+static int llcp_feats_req_handler(uint16_t conhdl, ke_task_id_t dest_id, bool int_ctx, struct llcp_feats_req *param); // :1485:12
+static int llcp_slave_feature_req_handler(uint16_t conhdl, ke_task_id_t dest_id, bool int_ctx, struct llcp_slave_feature_req *param); // :1542:12
+static int llcp_feats_rsp_handler(uint16_t conhdl, ke_task_id_t dest_id, bool int_ctx, struct llcp_feats_rsp *param); // :1565:12
+static int llcp_vers_ind_handler(uint16_t conhdl, ke_task_id_t dest_id, bool int_ctx, struct llcp_vers_ind *param); // :1626:12
+static int llcp_con_param_req_handler(uint16_t conhdl, ke_task_id_t dest_id, bool int_ctx, struct llcp_con_param_req *param); // :1690:12
+static int llcp_con_param_rsp_handler(uint16_t conhdl, ke_task_id_t dest_id, bool int_ctx, struct llcp_con_param_rsp *param); // :1881:12
+static int llcp_enc_req_handler(uint16_t conhdl, ke_task_id_t dest_id, bool int_ctx, struct llcp_enc_req *param); // :1974:12
+static int llcp_enc_rsp_handler(uint16_t conhdl, ke_task_id_t dest_id, bool int_ctx, struct llcp_enc_rsp *param); // :2051:12
+static int llcp_start_enc_req_handler(uint16_t conhdl, ke_task_id_t dest_id, bool int_ctx, struct llcp_start_enc_req *param); // :2118:12
+static int llcp_start_enc_rsp_handler(uint16_t conhdl, ke_task_id_t dest_id, bool int_ctx, struct llcp_start_enc_rsp *param); // :2173:12
+static int llcp_pause_enc_req_handler(uint16_t conhdl, ke_task_id_t dest_id, bool int_ctx, struct llcp_pause_enc_req *param); // :2268:12
+static int llcp_pause_enc_rsp_handler(uint16_t conhdl, ke_task_id_t dest_id, bool int_ctx, struct llcp_pause_enc_rsp *param); // :2341:12
+static int llcp_reject_ind_handler(uint16_t conhdl, ke_task_id_t dest_id, bool int_ctx, struct llcp_reject_ind *param); // :2417:12
+static int llcp_reject_ind_ext_handler(uint16_t conhdl, ke_task_id_t dest_id, bool int_ctx, struct llcp_reject_ind_ext *param); // :2438:12
+static int llcp_ping_req_handler(uint16_t conhdl, ke_task_id_t dest_id, bool int_ctx, void *param); // :2459:12
+static int llcp_ping_rsp_handler(uint16_t conhdl, ke_task_id_t dest_id, bool int_ctx, void *param); // :2491:12
+static int llcp_length_req_handler(uint16_t conhdl, ke_task_id_t dest_id, bool int_ctx, struct llcp_length_req *param); // :2531:12
+static int llcp_length_rsp_handler(uint16_t conhdl, ke_task_id_t dest_id, bool int_ctx, struct llcp_length_rsp *param); // :2623:12
+static int llcp_unknown_rsp_handler(uint16_t conhdl, ke_task_id_t dest_id, bool int_ctx, struct llcp_unknown_rsp *param); // :3051:12
+uint8_t llc_llcp_get_autorize(uint8_t opcode); // :3236:9
+
+/* ======== components/network/ble/blecontroller/ip/ble/ll/src/llc/llc_llcp.h ======== */
+
+struct llcp_pdu_tag {
+    struct co_list_hdr hdr;
+    uint16_t idx;
+    void *ptr;
+    uint8_t opcode;
+}; // :48:8
+
+enum llc_llcp_authorize {
+    LLC_LLCP_NO_AUTHZED = 0,
+    LLC_LLCP_START_ENC_AUTHZED = 1,
+    LLC_LLCP_PAUSE_ENC_AUTHZED = 2,
+}; // :66:6
+
+/* ======== components/network/ble/blecontroller/ip/ble/ll/src/llc/llc_task.c ======== */
+
+static void llc_task_random_gen_request(ke_task_id_t dest_id); // :85:13
+static int llc_enc_mgt_ind_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :115:12
+static int llc_link_sup_to_ind_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :344:12
+static int llc_auth_payl_nearly_to_ind_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :386:12
+static int llc_auth_payl_real_to_ind_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :445:12
+static int llc_llcp_rsp_to_ind_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :490:12
+static int llc_chnl_assess_timer_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :514:12
+static int llc_con_upd_req_ind_handler(const ke_msg_id_t msgid, struct llc_con_upd_req_ind *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :593:12
+static int llc_length_req_ind_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :812:12
+static int llc_chmap_update_req_ind_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :940:12
+static int llm_enc_ind_handler(const ke_msg_id_t msgid, const struct llm_enc_ind *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :994:12
+static int lld_stop_ind_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :1054:12
+static int llc_data_ind_handler(const ke_msg_id_t msgid, const struct llc_data_ind *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :1191:12
+static int llc_dft_handler(const ke_msg_id_t msgid, void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :1246:12
+static int llc_llcp_recv_ind_handler(const ke_msg_id_t msgid, struct llc_llcp_recv_ind *ind, ke_task_id_t dest_id, ke_task_id_t src_id); // :1268:12
+
+static const struct ke_msg_handler llc_default_state[16]; // :1285:36
+const struct ke_state_handler llc_default_handler; // :1356:31
+ke_state_t llc_state[2]; // :1359:12
+
+/* ======== components/network/ble/blecontroller/ip/ble/ll/src/llc/llc_task.h ======== */
+
+enum llc_op_type {
+    LLC_OP_LOC_PARAM_UPD = 0,
+    LLC_OP_REM_PARAM_UPD = 1,
+    LLC_OP_ENCRYPT = 2,
+    LLC_OP_DLE_UPD = 3,
+    LLC_OP_MAX = 4,
+}; // :56:6
+
+enum llc_proc_field {
+    LLC_LOC_PROC = 0,
+    LLC_REM_PROC = 1,
+    LLC_TRAFFIC_PAUSED = 2,
+    LLC_DISC = 3,
+}; // :80:6
+
+enum llc_state_id {
+    LLC_CONNECTED = 0,
+    LLC_LOC_PROC_BUSY = 1,
+    LLC_REM_PROC_BUSY = 2,
+    LLC_TRAFFIC_PAUSED_BUSY = 4,
+    LLC_DISC_BUSY = 15,
+    LLC_FREE = 127,
+    LLC_STATE_MAX = 128,
+}; // :95:6
+
+enum llc_loc_proc_state {
+    LLC_LOC_IDLE = 0,
+    LLC_LOC_WAIT_FEAT_RSP = 1,
+    LLC_LOC_WAIT_VERS_IND = 2,
+    LLC_LOC_WAIT_TERM_ACK = 3,
+    LLC_LOC_WAIT_LENGTH_RSP = 4,
+    LLC_LOC_WAIT_PING_RSP = 5,
+    LLC_LOC_WAIT_MAP_UPD_INSTANT = 6,
+    LLC_LOC_WAIT_CON_PARAM_RSP = 7,
+    LLC_LOC_WAIT_CON_UPD_REQ = 8,
+    LLC_LOC_WAIT_CON_UPD_INSTANT = 9,
+    LLC_LOC_WAIT_TRAFFIC_PAUSED = 10,
+    LLC_LOC_WAIT_PAUSE_ENC_RSP = 11,
+    LLC_LOC_WAIT_PAUSE_ENC_RSP_SENT = 12,
+    LLC_LOC_WAIT_ENC_RSP = 13,
+    LLC_LOC_WAIT_SK_AND_START_ENC_REQ = 14,
+    LLC_LOC_WAIT_SK = 15,
+    LLC_LOC_WAIT_START_ENC_REQ = 16,
+    LLC_LOC_SEND_START_ENC_RSP = 17,
+    LLC_LOC_WAIT_START_ENC_RSP = 18,
+    LLC_LOC_WAIT_RANDN_GEN_IND = 19,
+}; // :123:6
+
+enum llc_rem_proc_state {
+    LLC_REM_IDLE = 0,
+    LLC_REM_WAIT_MAP_UPD_INSTANT = 1,
+    LLC_REM_WAIT_CON_PARAM_HOST_RSP = 2,
+    LLC_REM_WAIT_CON_UPD_REQ = 3,
+    LLC_REM_WAIT_CON_UPD_INSTANT = 4,
+    LLC_REM_WAIT_TP_FOR_PAUSE_ENC_REQ = 5,
+    LLC_REM_WAIT_PAUSE_ENC_RSP = 6,
+    LLC_REM_WAIT_ENC_REQ = 7,
+    LLC_REM_WAIT_TP_FOR_ENC_REQ = 8,
+    LLC_REM_WAIT_LTK = 9,
+    LLC_REM_WAIT_SK = 10,
+    LLC_REM_WAIT_START_ENC_RSP = 11,
+    LLC_REM_WAIT_START_ENC_RSP_ACK = 12,
+    LLC_REM_WAIT_ENC_REJECT_ACK = 13,
+    LLC_REM_WAIT_RANDN_GEN_IND = 14,
+}; // :193:6
+
+enum LLC_MSG {
+    LLC_DATA_IND = 256,
+    LLC_LE_LINK_SUP_TO = 257,
+    LLC_LLCP_RSP_TO = 258,
+    LLC_AUTH_PAYL_NEARLY_TO = 259,
+    LLC_AUTH_PAYL_REAL_TO = 260,
+    LLC_CHNL_ASSESS_TO = 261,
+    LLC_ENC_MGT_IND = 262,
+    LLC_LENGTH_REQ_IND = 263,
+    LLC_CHMAP_UPDATE_REQ_IND = 264,
+    LLC_CON_UPD_REQ_IND = 265,
+    LLC_LLCP_RECV_IND = 266,
+}; // :254:6
+
+struct llc_create_con_req_ind {
+    uint16_t con_int;
+    uint16_t con_lat;
+    uint16_t sup_to;
+    uint16_t ral_ptr;
+    struct bd_addr peer_addr;
+    uint8_t peer_addr_type;
+    uint8_t hop_inc;
+    uint8_t sleep_clk_acc;
+    uint8_t filter_policy;
+}; // :366:8
+
+struct llc_data_ind {
+    uint16_t conhdl;
+    uint8_t pb_bc_flag;
+    uint16_t length;
+    uint8_t rx_hdl;
+}; // :389:8
+
+struct llc_llcp_recv_ind {
+    uint8_t status;
+    uint8_t dummy;
+    union llcp_pdu pdu;
+}; // :410:8
+
+enum llc_con_up_op {
+    LLC_CON_UP_HCI_REQ = 0,
+    LLC_CON_UP_MOVE_ANCHOR = 1,
+    LLC_CON_UP_FORCE = 2,
+    LLC_CON_UP_PEER_REQ = 3,
+    LLC_CON_UP_LOC_REQ = 4,
+}; // :422:6
+
+struct llc_con_upd_req_ind {
+    uint8_t operation;
+    uint16_t con_intv_min;
+    uint16_t con_intv_max;
+    uint16_t con_latency;
+    uint16_t superv_to;
+    uint16_t ce_len_min;
+    uint16_t ce_len_max;
+    uint16_t interval_min;
+    uint16_t interval_max;
+    uint8_t pref_period;
+    uint16_t ref_con_event_count;
+    uint16_t offset0;
+    uint16_t offset1;
+    uint16_t offset2;
+    uint16_t offset3;
+    uint16_t offset4;
+    uint16_t offset5;
+}; // :439:8
+
+const struct ke_state_handler llc_default_handler; // :489:38
+ke_state_t llc_state[2]; // :490:19
+
+/* ======== components/network/ble/blecontroller/ip/ble/ll/src/llc/llc_util.c ======== */
+
+static void llc_check_trafic_paused(uint8_t conhdl); // :50:13
+uint8_t llc_util_get_free_conhdl(uint16_t *conhdl); // :81:9
+uint8_t llc_util_get_nb_active_link(void); // :107:9
+void llc_util_dicon_procedure(uint16_t conhdl, uint8_t reason); // :132:6
+void llc_util_update_channel_map(uint16_t conhdl, struct le_chnl_map *map); // :156:6
+void llc_util_set_llcp_discard_enable(uint16_t conhdl, bool enable); // :168:6
+void llc_util_set_auth_payl_to_margin(struct lld_evt_tag *evt); // :186:6
+void llc_util_clear_operation_ptr(uint16_t conhdl, uint8_t op_type); // :211:6
+void llc_util_bw_mgt(uint16_t conhdl); // :223:6
+void llc_end_evt_defer(uint16_t conhdl); // :267:6
+void llc_pdu_llcp_tx_ack_defer(uint16_t conhdl, uint8_t opcode); // :295:6
+void llc_pdu_acl_tx_ack_defer(uint16_t conhdl, uint8_t tx_cnt); // :346:6
+void llc_pdu_defer(uint16_t conhdl, uint16_t status, uint8_t rssi, uint8_t channel, uint8_t length); // :378:6
+
+/* ======== components/network/ble/blecontroller/ip/ble/ll/src/llc/llc_util.h ======== */
+
+enum llc_util_enc_state {
+    LLC_ENC_DISABLED = 0,
+    LLC_ENC_TX = 1,
+    LLC_ENC_RX = 2,
+    LLC_ENC_ENABLE = 3,
+    LLC_ENC_TX_FLOW_OFF = 4,
+    LLC_ENC_RX_FLOW_OFF = 8,
+    LLC_ENC_FLOW_OFF = 12,
+    LLC_ENC_REFRESH_PENDING = 16,
+    LLC_ENC_PAUSE_PENDING = 32,
+}; // :108:6
+
+/* ======== components/network/ble/blecontroller/ip/ble/ll/src/lld/lld.c ======== */
+
+static const struct ke_task_desc TASK_DESC_LLD; // :93:34
+
+void lld_init(bool reset); // :116:6
+void lld_core_reset(void); // :492:6
+struct ea_elt_tag *lld_adv_start(struct advertising_pdu_params *adv_par, struct em_desc_node *adv_pdu, struct em_desc_node *scan_rsp_pdu, uint8_t adv_pwr); // :554:20
+void lld_adv_stop(struct ea_elt_tag *elt); // :1111:6
+struct ea_elt_tag *lld_scan_start(const struct scanning_pdu_params *scan_par, struct em_desc_node *scan_req_pdu); // :1127:20
+void lld_scan_stop(struct ea_elt_tag *elt); // :1258:6
+struct ea_elt_tag *lld_con_start(const struct hci_le_create_con_cmd *con_par, struct em_desc_node *con_req_pdu, uint16_t conhdl); // :1409:20
+struct ea_elt_tag *lld_move_to_master(struct ea_elt_tag *elt, uint16_t conhdl, const struct llc_create_con_req_ind *param, uint8_t rx_hdl); // :1772:20
+void lld_con_update_req(struct ea_elt_tag *elt_old, struct llc_con_upd_req_ind *param, struct llcp_con_upd_ind *param_pdu); // :1834:6
+uint8_t lld_con_update_after_param_req(uint16_t conhdl, struct ea_elt_tag *elt_old, struct llc_con_upd_req_ind *param, struct llcp_con_upd_ind *param_pdu, bool bypass_offchk); // :1860:9
+uint8_t lld_con_param_rsp(uint16_t conhdl, struct ea_elt_tag *elt, struct llc_con_upd_req_ind *param); // :2005:9
+void lld_con_param_req(uint16_t conhdl, struct ea_elt_tag *elt, struct llc_con_upd_req_ind *param); // :2069:6
+void lld_con_stop(struct ea_elt_tag *elt); // :2140:6
+uint8_t lld_get_mode(uint16_t conhdl); // :2145:9
+struct ea_elt_tag *lld_move_to_slave(struct llc_create_con_req_ind *con_par, struct llm_pdu_con_req_rx *con_req_pdu, struct ea_elt_tag *elt_adv, uint16_t conhdl, uint8_t rx_hdl); // :2185:20
+void lld_ch_map_ind(struct ea_elt_tag *elt, uint16_t instant); // :2471:6
+void lld_con_update_ind(struct ea_elt_tag *elt_old, const struct llcp_con_upd_ind *param_pdu); // :2502:6
+void lld_crypt_isr(void); // :2543:6
+struct ea_elt_tag *lld_test_mode_tx(struct em_desc_node *txdesc, uint8_t tx_freq, uint8_t tx_phy); // :2550:20
+
+uint8_t orig_rxsyncwinszdef; // :2622:9
+uint8_t orig_rfrxtmda; // :2623:9
+
+struct ea_elt_tag *lld_test_mode_rx(uint8_t rx_freq); // :2624:20
+struct ea_elt_tag *lld_enh_test_mode_rx(uint8_t rx_freq, uint8_t rx_phy, uint8_t modul_index); // :2704:20
+void lld_test_stop(struct ea_elt_tag *elt); // :2777:6
+
+/* ======== components/network/ble/blecontroller/ip/ble/ll/src/lld/lld_evt.c ======== */
+
+enum lld_evt_defer_type {
+    LLD_DEFER_RX = 0,
+    LLD_DEFER_END = 1,
+    LLD_DEFER_TEST_END = 2,
+    LLD_DEFER_CON_UP_INSTANT = 3,
+    LLD_DEFER_MAP_UP_INSTANT = 4,
+    LLD_DEFER_MAX = 5,
+}; // :105:6
+
+struct lld_evt_env_tag lld_evt_env; // :133:24
+
+static void lld_evt_elt_wait_insert(struct ea_elt_tag *elt); // :170:13
+static struct lld_evt_wait_tag *lld_evt_elt_wait_get(struct ea_elt_tag *elt); // :179:34
+static void lld_evt_deferred_elt_push(struct ea_elt_tag *elt, uint8_t type, uint8_t rx_desc_cnt); // :224:13
+static void lld_evt_delete_elt_handler(void); // :246:13
+static struct ea_elt_tag *lld_evt_deferred_elt_pop(uint8_t *type, uint8_t *rx_desc_cnt); // :317:27
+static void lld_evt_winsize_change(struct lld_evt_tag *evt, bool instant); // :489:13
+static void lld_evt_rxwin_compute(struct ea_elt_tag *elt); // :560:13
+static void lld_evt_slave_time_compute(struct ea_elt_tag *elt, uint16_t slot_offset); // :618:13
+static uint32_t lld_evt_get_next_free_slot(void); // :938:17
+void lld_evt_delete_elt_push(struct ea_elt_tag *elt, bool flush, bool send_indication); // :1292:6
+void lld_evt_channel_next(uint16_t conhdl, int16_t nb_inc); // :1327:6
+void lld_evt_init(bool reset); // :1347:6
+void lld_evt_init_evt(struct lld_evt_tag *evt); // :1384:6
+bool lld_evt_restart(struct ea_elt_tag *elt, bool rejected); // :1406:5
+void lld_evt_elt_insert(struct ea_elt_tag *elt, bool inc_prio); // :1930:6
+bool lld_evt_elt_delete(struct ea_elt_tag *elt, bool flush_data, bool send_indication); // :1969:5
+uint16_t lld_evt_drift_compute(uint16_t delay, uint8_t master_sca); // :2105:10
+void lld_evt_schedule_next(struct ea_elt_tag *elt); // :2120:6
+void lld_evt_schedule(struct ea_elt_tag *elt); // :2278:6
+void lld_evt_prevent_stop(struct ea_elt_tag *elt); // :2525:6
+struct ea_elt_tag *lld_evt_scan_create(uint16_t handle, uint16_t latency); // :2533:20
+struct ea_elt_tag *lld_evt_move_to_master(struct ea_elt_tag *elt_scan, uint16_t conhdl, const struct llc_create_con_req_ind *pdu_tx, uint8_t rx_hdl); // :2572:20
+struct ea_elt_tag *lld_evt_update_create(struct ea_elt_tag *elt_old, uint16_t ce_len, uint16_t mininterval, uint16_t maxinterval, uint16_t latency, uint8_t pref_period, struct lld_evt_update_tag *upd_par); // :2679:20
+struct ea_elt_tag *lld_evt_move_to_slave(struct llc_create_con_req_ind *con_par, struct llm_pdu_con_req_rx *con_req_pdu, struct ea_elt_tag *elt_adv, uint16_t conhdl); // :2748:20
+void lld_evt_slave_update(const struct llcp_con_upd_ind *param_pdu, struct ea_elt_tag *elt_old); // :2951:6
+struct ea_elt_tag *lld_evt_adv_create(uint16_t handle, uint16_t mininterval, uint16_t maxinterval, bool restart_pol); // :3056:20
+void lld_evt_deffered_elt_handler(void); // :3108:6
+void lld_evt_end(struct ea_elt_tag *elt); // :3215:6
+void lld_evt_rx(struct ea_elt_tag *elt); // :3362:6
+void lld_evt_rx_afs(struct ea_elt_tag *elt, uint8_t num); // :3384:6
+void lld_evt_canceled(struct ea_elt_tag *elt); // :3410:6
+void lld_evt_timer_isr(void); // :3439:6
+void lld_evt_end_isr(bool apfm); // :3449:6
+void lld_evt_rx_isr(void); // :3479:6
+void lld_evt_afs_isr(uint8_t num); // :3489:6
+
+/* ======== components/network/ble/blecontroller/ip/ble/ll/src/lld/lld_evt.h ======== */
+
+enum lld_evt_flag {
+    LLD_EVT_FLAG_WAITING_ACK = 1,
+    LLD_EVT_FLAG_WAITING_SYNC = 2,
+    LLD_EVT_FLAG_WAITING_TXPROG = 4,
+    LLD_EVT_FLAG_WAITING_INSTANT = 8,
+    LLD_EVT_FLAG_WAITING_EOEVT_TO_DELETE = 16,
+    LLD_EVT_FLAG_NO_RESTART = 32,
+    LLD_EVT_FLAG_APFM = 64,
+    LLD_EVT_FLAG_LATENCY_ACTIVE = 128,
+}; // :147:6
+
+enum lld_evt_mode {
+    LLD_EVT_ADV_MODE = 0,
+    LLD_EVT_SCAN_MODE = 1,
+    LLD_EVT_TEST_MODE = 2,
+    LLD_EVT_MST_MODE = 3,
+    LLD_EVT_SLV_MODE = 4,
+    LLD_EVT_EXT_ADV_MODE = 5,
+    LLD_EVT_PER_ADV_MODE = 6,
+    LLD_EVT_EXT_SCAN_MODE = 7,
+    LLD_EVT_MODE_MAX = 8,
+}; // :188:6
+
+enum lld_evt_cs_format {
+    LLD_MASTER_CONNECTED = 2,
+    LLD_SLAVE_CONNECTED = 3,
+    LLD_LD_ADVERTISER = 4,
+    LLD_HD_ADVERTISER = 5,
+    LLD_PASSIVE_SCANNING = 8,
+    LLD_ACTIVE_SCANNING = 9,
+    LLD_INITIATING = 15,
+    LLD_TXTEST_MODE = 28,
+    LLD_RXTEST_MODE = 29,
+    LLD_TXRXTEST_MODE = 30,
+}; // :204:6
+
+struct lld_evt_anchor {
+    uint32_t basetime_cnt;
+    uint16_t finetime_cnt;
+    uint16_t evt_cnt;
+}; // :235:8
+
+struct lld_non_conn {
+    uint32_t window;
+    uint32_t anchor;
+    uint32_t end_ts;
+    bool initiate;
+    bool connect_req_sent;
+}; // :246:8
+
+struct lld_conn {
+    uint32_t sync_win_size;
+    uint32_t sca_drift;
+    uint16_t instant;
+    uint16_t latency;
+    uint16_t counter;
+    uint16_t missed_cnt;
+    uint16_t duration_dft;
+    uint16_t update_offset;
+    uint16_t eff_max_tx_time;
+    uint16_t eff_max_tx_size;
+    uint8_t update_size;
+    uint8_t instant_action;
+    uint8_t mst_sca;
+    uint8_t last_md_rx;
+    uint8_t tx_prog_pkt_cnt;
+    bool wait_con_up_sync;
+}; // :267:8
+
+struct lld_evt_tag {
+    struct lld_evt_anchor anchor_point;
+    struct co_list tx_acl_rdy;
+    struct co_list tx_acl_tofree;
+    struct co_list tx_llcp_pdu_rdy;
+    struct co_list tx_prog;
+    struct ea_interval_tag *interval_elt;
+    union lld_evt_info evt;
+    uint16_t conhdl;
+    uint16_t cs_ptr;
+    uint16_t interval;
+    uint8_t rx_cnt;
+    uint8_t mode;
+    uint8_t tx_pwr;
+    uint8_t default_prio;
+    uint8_t evt_flag;
+    bool delete_ongoing;
+}; // :304:8
+
+union lld_evt_info {
+    struct lld_non_conn non_conn;
+    struct lld_conn conn;
+}; // :325:11
+
+struct lld_evt_update_tag {
+    uint16_t win_offset;
+    uint16_t instant;
+    uint8_t win_size;
+}; // :361:8
+
+struct lld_evt_env_tag {
+    struct co_list elt_prog;
+    struct co_list elt_wait;
+    struct co_list elt_deferred;
+    struct co_list rx_pkt_deferred;
+    struct co_list elt_to_be_deleted;
+    uint8_t sca;
+    bool renew;
+    uint8_t hw_wa_sleep_compensation;
+}; // :385:8
+
+struct lld_evt_wait_tag {
+    struct co_list_hdr hdr;
+    struct ea_elt_tag *elt_ptr;
+}; // :406:8
+
+struct lld_evt_deferred_tag {
+    struct co_list_hdr hdr;
+    struct ea_elt_tag *elt_ptr;
+    uint8_t type;
+    uint8_t rx_desc_cnt;
+}; // :415:8
+
+struct lld_evt_delete_tag {
+    struct co_list_hdr hdr;
+    struct ea_elt_tag *elt_ptr;
+    bool flush;
+    bool send_ind;
+}; // :431:8
+
+struct lld_evt_env_tag lld_evt_env; // :450:31
+
+/* ======== components/network/ble/blecontroller/ip/ble/ll/src/lld/lld_pdu.c ======== */
+
+enum lld_pdu_pack_status {
+    LLC_PDU_PACK_OK = 0,
+    LLC_PDU_PACK_WRONG_FORMAT = 1,
+    LLC_PDU_PACK_UNKNOWN = 2,
+}; // :68:6
+
+typedef void (*llcp_pdu_unpk_func_t)(uint16_t, uint8_t, uint8_t *); // :94:16
+
+struct lld_pdu_rx_info {
+    struct co_list_hdr hdr;
+    uint8_t rx_hdl;
+    bool free;
+    uint16_t conhdl;
+    uint16_t status;
+    uint8_t length;
+    uint8_t channel;
+    uint8_t rssi;
+    uint8_t audio;
+}; // :98:8
+
+struct lld_pdu_pack_desc {
+    uint8_t pdu_len;
+    void *pack_fmt;
+    llcp_pdu_unpk_func_t unpack_func;
+}; // :121:8
+
+const struct lld_pdu_pack_desc lld_pdu_adv_pk_desc_tab[7]; // :132:32
+const struct lld_pdu_pack_desc lld_pdu_llcp_pk_desc_tab[22]; // :145:32
+
+static void lld_pdu_cntl_aligned_unpk(uint16_t pdu_ptr, uint8_t parlen, uint8_t *param); // :587:13
+static void lld_pdu_llcp_con_param_req_unpk(uint16_t pdu_ptr, uint8_t parlen, uint8_t *param); // :608:13
+static void lld_pdu_llcp_con_param_rsp_unpk(uint16_t pdu_ptr, uint8_t parlen, uint8_t *param); // :660:13
+static void lld_pdu_llcp_length_req_unpk(uint16_t pdu_ptr, uint8_t parlen, uint8_t *param); // :711:13
+static void lld_pdu_llcp_length_rsp_unpk(uint16_t pdu_ptr, uint8_t parlen, uint8_t *param); // :738:13
+static uint8_t lld_pdu_pack(uint8_t *p_data, uint8_t *p_length, const char *format); // :854:16
+static uint8_t lld_pdu_tx_flush_list(struct co_list *list); // :954:16
+bool lld_pdu_check(struct lld_evt_tag *evt); // :996:5
+void lld_pdu_tx_loop(struct lld_evt_tag *evt); // :1182:6
+void lld_pdu_data_tx_push(struct lld_evt_tag *evt, struct em_desc_node *txnode, bool can_be_freed, bool encrypted); // :1199:6
+bool lld_pdu_data_send(void *param); // :1251:5
+void lld_pdu_tx_push(struct ea_elt_tag *elt, struct em_desc_node *txnode); // :1278:6
+void lld_pdu_tx_prog(struct lld_evt_tag *evt); // :1311:6
+void lld_pdu_tx_flush(struct lld_evt_tag *evt); // :1558:6
+uint8_t lld_pdu_adv_pack(uint8_t code, uint8_t *buf, uint8_t *p_len); // :1596:9
+void lld_pdu_rx_handler(struct lld_evt_tag *evt, uint8_t nb_rx_desc); // :1677:6
+
+/* ======== components/network/ble/blecontroller/ip/ble/ll/src/lld/lld_pdu.h ======== */
+
+struct lld_pdu_data_tx_tag {
+    struct co_list_hdr hdr;
+    uint16_t idx;
+    uint16_t conhdl;
+    uint16_t length;
+    uint8_t pb_bc_flag;
+    struct em_buf_node *buf;
+}; // :45:8
+
+/* ======== components/network/ble/blecontroller/ip/ble/ll/src/lld/lld_sleep.c ======== */
+
+struct lld_sleep_env_tag {
+    uint32_t irq_mask;
+    int32_t last_sleep_dur;
+    bool sw_wakeup;
+    bool pds_reset;
+    uint32_t basetimecnt;
+    uint32_t finetimecnt;
+}; // :44:8
+
+static struct lld_sleep_env_tag lld_sleep_env; // :68:33
+
+uint32_t lld_sleep_get_pds_reset(void); // :391:10
+void lld_sleep_set_current_time(void); // :396:6
+
+/* ======== components/network/ble/blecontroller/ip/ble/ll/src/lld/lld_util.c ======== */
+
+uint16_t lld_util_instant_get(void *event, uint8_t action); // :54:10
+void lld_util_get_bd_address(struct bd_addr *bd_addr); // :80:6
+void lld_util_set_bd_address(struct bd_addr *bd_addr, uint8_t type); // :87:6
+uint8_t lld_util_freq2chnl(uint8_t freq); // :122:9
+uint16_t lld_util_get_local_offset(uint16_t PeerOffset, uint16_t Interval, uint32_t AnchorPoint); // :160:10
+uint16_t lld_util_get_peer_offset(uint16_t LocalOffset, uint16_t Interval, uint32_t AnchorPoint); // :169:10
+void lld_util_connection_param_set(struct ea_elt_tag *elt, struct ea_param_output *param); // :178:6
+void lld_util_dle_set_cs_fields(uint16_t conhdl); // :217:6
+void lld_util_anchor_point_move(struct ea_elt_tag *elt_connect); // :224:6
+void lld_util_flush_list(struct co_list *list); // :271:6
+bool lld_util_instant_ongoing(struct ea_elt_tag *elt); // :288:5
+void lld_util_compute_ce_max(struct ea_elt_tag *elt, uint16_t tx_time, uint16_t rx_time); // :294:6
+bool lld_util_elt_programmed(struct ea_elt_tag *elt); // :428:5
+void lld_util_priority_set(struct ea_elt_tag *elt, uint8_t priority_index); // :442:6
+void lld_util_priority_update(struct ea_elt_tag *elt, uint8_t value); // :528:6
+uint8_t lld_util_get_tx_pkt_cnt(struct ea_elt_tag *elt); // :537:9
+void lld_util_eff_tx_time_set(struct ea_elt_tag *elt, uint16_t max_tx_time, uint16_t max_tx_size); // :546:6
+
+/* ======== components/network/ble/blecontroller/ip/ble/ll/src/lld/lld_util.h ======== */
+
+enum lld_util_instant_action {
+    LLD_UTIL_NO_ACTION = 0,
+    LLD_UTIL_PARAM_UPDATE = 1,
+    LLD_UTIL_CHMAP_UPDATE = 2,
+}; // :48:6
+
+/* ======== components/network/ble/blecontroller/ip/ble/ll/src/lld/lld_wlcoex.c ======== */
+
+void lld_wlcoex_set(bool en); // :38:6
+void coex_dump_ble(void); // :124:6
+
+/* ======== components/network/ble/blecontroller/ip/ble/ll/src/llm/llm.c ======== */
+
+struct llm_le_env_tag llm_le_env; // :82:23
+static const struct bd_addr llm_dflt_bdaddr; // :89:29
+const struct supp_cmds llm_local_cmds; // :92:24
+uint8_t llm_local_supp_feats[3]; // :102:9
+const struct le_features llm_local_le_feats; // :140:26
+const struct le_states llm_local_le_states; // :145:24
+const struct data_len_ext llm_local_data_len_values; // :152:27
+static const struct ke_task_desc TASK_DESC_LLM; // :158:34
+
+static void llm_wlpub_addr_set(uint16_t elem_index, const struct bd_addr *bdaddr); // :166:13
+static void llm_wlpriv_addr_set(uint16_t elem_index, const struct bd_addr *bdaddr); // :175:13
+void llm_init(bool reset); // :560:6
+void llm_ble_ready(void); // :803:6
+void llm_con_req_ind(uint8_t rx_hdl, uint16_t status); // :810:6
+void llm_le_adv_report_ind(uint8_t rx_hdl); // :920:6
+void llm_con_req_tx_cfm(uint8_t rx_hdl); // :1214:6
+void llm_common_cmd_complete_send(uint16_t opcode, uint8_t status); // :1309:6
+void llm_common_cmd_status_send(uint16_t opcode, uint8_t status); // :1319:6
+uint8_t llm_test_mode_start_tx(const struct hci_le_tx_test_cmd *param); // :1331:9
+uint8_t llm_test_mode_start_rx(const struct hci_le_rx_test_cmd *param); // :1418:9
+uint8_t llm_set_adv_param(const struct hci_le_set_adv_param_cmd *param); // :1572:9
+uint8_t llm_set_adv_en(const struct hci_le_set_adv_en_cmd *param); // :1702:9
+uint8_t llm_set_adv_data(const struct hci_le_set_adv_data_cmd *param); // :1864:9
+uint8_t llm_set_scan_rsp_data(const struct hci_le_set_scan_rsp_data_cmd *param); // :1891:9
+uint8_t llm_set_scan_param(const struct hci_le_set_scan_param_cmd *param); // :3179:9
+uint8_t llm_set_scan_en(const struct hci_le_set_scan_en_cmd *param); // :3238:9
+void llm_wl_clr(void); // :3576:6
+void llm_wl_dev_add(struct bd_addr *bd_addr, uint8_t bd_addr_type); // :3603:6
+void llm_wl_dev_rem(struct bd_addr *bd_addr, uint8_t bd_addr_type); // :3623:6
+uint8_t llm_wl_dev_add_hdl(struct bd_addr *bd_addr, uint8_t bd_addr_type); // :3645:9
+uint8_t llm_wl_dev_rem_hdl(struct bd_addr *bd_addr, uint8_t bd_addr_type); // :3700:9
+uint8_t llm_create_con(const struct hci_le_create_con_cmd *param); // :3745:9
+void llm_encryption_done(void); // :3888:6
+void llm_encryption_start(const struct llm_enc_req *param); // :3958:6
+
+/* ======== components/network/ble/blecontroller/ip/ble/ll/src/llm/llm.h ======== */
+
+enum llm_enh_priv {
+    LLM_PRIV_RFU_MASK = 140,
+    LLM_PRIV_RFU_LSB = 2,
+    LLM_RPA_RENEW_TIMER_EN_MASK = 2,
+    LLM_RPA_RENEW_TIMER_EN_LSB = 1,
+    LLM_PRIV_ENABLE_MASK = 1,
+    LLM_PRIV_ENABLE_LSB = 0,
+}; // :74:6
+
+struct advertising_pdu_params {
+    struct ke_msg *adv_data_req;
+    struct ke_msg *scan_rsp_req;
+    struct em_buf_node *adv_desc_node;
+    struct em_buf_node *scan_rsp_desc_node;
+    struct bd_addr peer_addr;
+    uint16_t intervalmin;
+    uint16_t intervalmax;
+    uint8_t channelmap;
+    uint8_t filterpolicy;
+    uint8_t type;
+    uint8_t datalen;
+    uint8_t scanrsplen;
+    uint8_t own_addr_type;
+    uint8_t peer_addr_type;
+    bool adv_ldc_flag;
+}; // :94:8
+
+struct scanning_pdu_params {
+    struct em_buf_node *conn_req_desc_node;
+    uint16_t interval;
+    uint16_t window;
+    uint8_t filterpolicy;
+    uint8_t type;
+    uint8_t filter_duplicate;
+    uint8_t own_addr_type;
+}; // :138:8
+
+struct access_addr_gen {
+    uint8_t intrand;
+    uint8_t ct1_idx;
+    uint8_t ct2_idx;
+}; // :183:8
+
+struct adv_device_list {
+    struct co_list_hdr hdr;
+    uint8_t adv_type;
+    struct bd_addr adv_addr;
+}; // :194:8
+
+struct llm_pdu_adv {
+    struct bd_addr adva;
+    uint8_t *adva_data;
+}; // :215:8
+
+struct llm_pdu_con_req_rx {
+    struct bd_addr inita;
+    struct bd_addr adva;
+    struct access_addr aa;
+    struct crc_init crcinit;
+    uint8_t winsize;
+    uint16_t winoffset;
+    uint16_t interval;
+    uint16_t latency;
+    uint16_t timeout;
+    struct le_chnl_map chm;
+    uint8_t hop_sca;
+}; // :251:8
+
+struct llm_pdu_con_req_tx {
+    struct access_addr aa;
+    struct crc_init crcinit;
+    uint8_t winsize;
+    uint16_t winoffset;
+    uint16_t interval;
+    uint16_t latency;
+    uint16_t timeout;
+    struct le_chnl_map chm;
+    uint8_t hop_sca;
+}; // :277:8
+
+struct llm_test_mode {
+    bool end_of_tst;
+    uint8_t directtesttype;
+}; // :324:8
+
+struct data_len_ext {
+    uint16_t conn_initial_max_tx_octets;
+    uint16_t conn_initial_max_tx_time;
+    uint16_t suppted_max_tx_octets;
+    uint16_t suppted_max_tx_time;
+    uint16_t suppted_max_rx_octets;
+    uint16_t suppted_max_rx_time;
+}; // :337:8
+
+enum t_key_multiplication_type {
+    LLM_ECC_IDLE = 0,
+    LLM_PUBLIC_KEY_GENERATION = 1,
+    LLM_DHKEY_GENERATION = 2,
+}; // :354:14
+
+typedef enum t_key_multiplication_type t_key_multi_type; // :359:3
+
+struct t_public_key256 {
+    uint8_t x[32];
+    uint8_t y[32];
+}; // :361:16
+
+typedef struct t_public_key256 t_public_key256; // :365:3
+
+struct channel_map_assess {
+    uint16_t assess_timer;
+    int8_t lower_limit;
+    int8_t upper_limit;
+    int8_t rssi_noise_limit;
+    uint8_t reassess_count;
+    struct le_chnl_map ch_map;
+    bool llm_le_set_host_ch_class_cmd_sto;
+}; // :369:8
+
+struct llm_le_env_tag {
+    struct co_list enc_req;
+    struct co_list adv_list;
+    struct scanning_pdu_params *scanning_params;
+    struct advertising_pdu_params *advertising_params;
+    struct co_list cnx_list;
+    struct data_len_ext data_len_val;
+    struct channel_map_assess ch_map_assess;
+    struct evt_mask eventmask;
+    struct access_addr_gen aa;
+    uint16_t conhdl_alloc;
+    struct ea_elt_tag *elt;
+    bool last_opcode;
+    uint16_t opcode2;
+    uint8_t state2;
+    struct ea_elt_tag *elt_coext_scan;
+    bool enc_pend;
+    struct llm_test_mode test_mode;
+    struct bd_addr rand_add;
+    struct bd_addr public_add;
+    uint16_t enh_priv_rpa_timeout;
+    uint16_t p256_byte_process_timeout;
+    uint16_t opcode;
+    uint8_t state;
+    uint8_t enh_priv_info;
+    uint8_t curr_addr_type;
+    uint8_t nb_dev_in_wl;
+    uint8_t nb_dev_in_hw_wl;
+    t_public_key256 public_key256;
+    uint8_t secret_key256[32];
+    t_key_multi_type cur_ecc_multiplication;
+}; // :406:8
+
+const struct supp_cmds llm_local_cmds; // :558:31
+uint8_t llm_local_supp_feats[3]; // :559:16
+const struct le_features llm_local_le_feats; // :560:33
+const struct le_states llm_local_le_states; // :561:31
+const struct data_len_ext llm_local_data_len_values; // :563:34
+struct llm_le_env_tag llm_le_env; // :779:30
+
+/* ======== components/network/ble/blecontroller/ip/ble/ll/src/llm/llm_hci.c ======== */
+
+static int hci_le_set_evt_mask_cmd_handler(const ke_msg_id_t msgid, const struct hci_le_set_evt_mask_cmd *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :89:12
+static int hci_le_set_rand_add_cmd_handler(const ke_msg_id_t msgid, const struct hci_le_set_rand_addr_cmd *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :115:12
+static int hci_le_set_adv_param_cmd_handler(const ke_msg_id_t msgid, const struct hci_le_set_adv_param_cmd *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :212:12
+static int hci_le_rd_trans_pwr_cmd_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :1098:12
+
+uint16_t g_rf_txpath_compensation_value; // :1117:10
+uint16_t g_rf_rxpath_compensation_value; // :1118:10
+
+static int hci_le_rd_rfpath_compensation_cmd_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :1119:12
+static int hci_le_wr_rfpath_compensation_cmd_handler(const ke_msg_id_t msgid, const struct hci_le_wr_rfpath_cps_cmd *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :1138:12
+static int hci_le_rd_adv_ch_tx_pw_cmd_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :1171:1
+static int hci_le_set_adv_data_cmd_handler(const ke_msg_id_t msgid, const struct hci_le_set_adv_data_cmd *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :1208:12
+static int hci_le_set_adv_en_cmd_handler(const ke_msg_id_t msgid, const struct hci_le_set_adv_en_cmd *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :1278:1
+static int hci_le_set_scan_rsp_data_cmd_handler(const ke_msg_id_t msgid, const struct hci_le_set_scan_rsp_data_cmd *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :1395:1
+static int hci_le_set_scan_param_cmd_handler(const ke_msg_id_t msgid, const struct hci_le_set_scan_param_cmd *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :1473:1
+static int hci_le_set_scan_en_cmd_handler(const ke_msg_id_t msgid, const struct hci_le_set_scan_en_cmd *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :1519:1
+static int hci_le_rx_test_cmd_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :1652:12
+static int hci_le_tx_test_cmd_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :1707:12
+static int hci_le_wl_mngt_cmd_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :1772:12
+static int hci_le_create_con_cmd_handler(const ke_msg_id_t msgid, const struct hci_le_create_con_cmd *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :1874:12
+static int hci_le_create_con_cancel_cmd_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :1940:12
+static int hci_le_set_host_ch_class_cmd_handler(const ke_msg_id_t msgid, const struct hci_le_set_host_ch_class_cmd *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :2012:12
+static int hci_le_rd_local_supp_feats_cmd_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :2075:12
+static int hci_le_rd_wl_size_cmd_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :2111:12
+static int hci_le_rd_supp_states_cmd_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :2145:12
+static int hci_le_rd_buff_size_cmd_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :2179:12
+static int hci_le_enc_cmd_handler(const ke_msg_id_t msgid, const struct hci_le_enc_cmd *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :2214:12
+static int hci_le_rand_cmd_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :2252:12
+static int hci_le_test_end_cmd_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :2287:12
+static int hci_reset_cmd_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :2337:12
+static int hci_rd_bd_addr_cmd_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :2363:12
+static int hci_rd_local_ver_info_cmd_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :2393:12
+static int hci_rd_local_supp_cmds_cmd_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :2431:12
+static int hci_rd_local_supp_feats_cmd_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :2464:12
+static int hci_wr_le_host_supp_cmd_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :2481:12
+static int hci_set_evt_mask_cmd_handler(const ke_msg_id_t msgid, const struct hci_set_evt_mask_cmd *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :2503:12
+static int hci_set_evt_mask_page_2_cmd_handler(const ke_msg_id_t msgid, const struct hci_set_evt_mask_cmd *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :2529:12
+static int hci_set_ctrl_to_host_flow_ctrl_cmd_handler(const ke_msg_id_t msgid, const struct hci_set_ctrl_to_host_flow_ctrl_cmd *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :2556:12
+static int hci_host_buf_size_cmd_handler(const ke_msg_id_t msgid, const struct hci_host_buf_size_cmd *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :2605:12
+static int hci_host_nb_cmp_pkts_cmd_handler(const ke_msg_id_t msgid, const struct hci_host_nb_cmp_pkts_cmd *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :2631:12
+static int hci_rd_buff_size_cmd_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :2683:12
+static int hci_le_rd_suggted_dft_data_len_cmd_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :2724:12
+static int hci_le_wr_suggted_dft_data_len_cmd_handler(const ke_msg_id_t msgid, const struct hci_le_wr_suggted_dft_data_len_cmd *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :2754:12
+static int hci_le_rd_max_data_len_cmd_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :2807:12
+static int hci_le_rd_local_p256_public_key_cmd_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :3045:12
+static int hci_le_generate_dhkey_cmd_handler(const ke_msg_id_t msgid, struct hci_le_generate_dh_key_cmd *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :3111:12
+static int hci_vsc_set_tx_pwr(const ke_msg_id_t msgid, struct hci_vsc_set_tx_pwr_cmd *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :3226:12
+
+static const struct ke_msg_handler llm_hci_command_handler_tab[45]; // :3246:36
+
+int hci_command_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :3390:5
+
+/* ======== components/network/ble/blecontroller/ip/ble/ll/src/llm/llm_task.c ======== */
+
+static int llm_enc_req_handler(const ke_msg_id_t msgid, const struct llm_enc_req *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :85:12
+static int llm_ecc_result_ind_handler(const ke_msg_id_t msgid, const struct ecc_result_ind *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :120:12
+static int lld_stop_ind_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :236:12
+static int llm_dft_handler(const ke_msg_id_t msgid, void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :406:12
+static int llm_le_set_host_ch_class_cmd_sto_handler(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :429:12
+
+static const struct ke_msg_handler llm_default_state[7]; // :462:36
+const struct ke_state_handler llm_default_handler; // :491:31
+ke_state_t llm_state[1]; // :494:12
+
+/* ======== components/network/ble/blecontroller/ip/ble/ll/src/llm/llm_task.h ======== */
+
+enum llm_state_id {
+    LLM_ADV_STATE_MASK = 240,
+    LLM_SCAN_INIT_STATE_MASK = 15,
+    LLM_COEXT_IDLE_IDLE = 0,
+    LLM_COEXT_ADVERTISING_IDLE = 16,
+    LLM_COEXT_STOPPING_IDLE = 32,
+    LLM_COEXT_IDLE_SCANNING = 1,
+    LLM_COEXT_IDLE_INITIATING = 2,
+    LLM_COEXT_IDLE_STOPPING = 3,
+    LLM_COEXT_ADVERTISING_SCANNING = 17,
+    LLM_COEXT_ADVERTISING_INITIATING = 18,
+    LLM_COEXT_ADVERTISING_STOPPING = 19,
+    LLM_COEXT_STOPPING_SCANNING = 33,
+    LLM_COEXT_STOPPING_INITIATING = 34,
+    LLM_COEXT_STOPPING_STOPPING = 35,
+    LLM_TEST = 36,
+    LLM_STATE_MAX = 37,
+}; // :53:6
+
+enum llm_msg_id {
+    LLM_LE_SET_HOST_CH_CLASS_CMD_STO = 0,
+    LLM_STOP_IND = 1,
+    LLM_LE_SET_HOST_CH_CLASS_REQ = 2,
+    LLM_LE_SET_HOST_CH_CLASS_REQ_IND = 3,
+    LLM_ENC_REQ = 4,
+    LLM_ENC_IND = 5,
+    LLM_ECC_RESULT_IND = 6,
+    LLM_LE_CHNL_ASSESS_TIMER = 7,
+    LLM_GEN_CHNL_CLS_CMD = 8,
+    LLM_LE_ENH_PRIV_ADDR_RENEW_TIMER = 9,
+}; // :121:6
+
+struct llm_enc_req {
+    struct ltk key;
+    uint8_t plain_data[16];
+}; // :171:8
+
+struct llm_enc_ind {
+    uint8_t status;
+    uint8_t encrypted_data[16];
+}; // :180:8
+
+const struct ke_state_handler llm_default_handler; // :192:38
+ke_state_t llm_state[1]; // :193:19
+
+/* ======== components/network/ble/blecontroller/ip/ble/ll/src/llm/llm_util.c ======== */
+
+const uint8_t LLM_AA_CT1[3]; // :48:15
+const uint8_t LLM_AA_CT2[2]; // :51:15
+
+struct llm_util_cnx_bd_addr_tag {
+    struct co_list_hdr hdr;
+    struct bd_addr dev_addr;
+    uint16_t conhdl;
+    uint8_t dev_addr_type;
+    bool in_wl;
+}; // :59:8
+
+uint16_t llm_util_bd_addr_wl_position(const struct bd_addr *bd_address, uint8_t bd_addr_type); // :79:10
+bool llm_util_bd_addr_in_wl(const struct bd_addr *bd_address, uint8_t bd_addr_type, bool *in_black_list); // :120:5
+uint8_t llm_util_check_address_validity(struct bd_addr *bd_address, uint8_t addr_type); // :158:9
+uint8_t llm_util_check_map_validity(uint8_t *channel_map, uint8_t nb_octet); // :177:9
+void llm_util_apply_bd_addr(uint8_t addr_type); // :217:6
+void llm_util_set_public_addr(struct bd_addr *bd_addr); // :257:6
+bool llm_util_check_evt_mask(uint8_t event_id); // :269:5
+void llm_util_get_channel_map(struct le_chnl_map *map); // :274:6
+void llm_util_get_supp_features(struct le_features *feats); // :282:6
+void llm_util_adv_data_update(void); // :288:6
+uint8_t llm_util_bl_check(const struct bd_addr *bd_addr_to_add, uint8_t bd_addr_type, uint16_t *conhdl, uint8_t wl_flag_action, bool *in_wl); // :361:9
+uint8_t llm_util_bl_add(struct bd_addr *bd_addr_to_add, uint8_t bd_addr_type, uint16_t conhdl); // :403:9
+uint8_t llm_util_bl_rem(uint16_t conhdl); // :442:9
+void llm_end_evt_defer(void); // :524:6
+bool llm_pdu_defer(uint16_t status, uint8_t rx_hdl, uint8_t tx_cnt); // :580:5
+
+/* ======== components/network/ble/blecontroller/ip/ble/ll/src/llm/llm_util.h ======== */
+
+const uint8_t LLM_AA_CT1[3]; // :72:22
+const uint8_t LLM_AA_CT2[2]; // :75:22
+
+enum bl_flag_wl {
+    LLM_UTIL_BL_NO_ACTION_WL = 0,
+    LLM_UTIL_BL_CLEAR_WL = 1,
+    LLM_UTIL_BL_SET_WL = 2,
+}; // :77:6
+
+uint8_t orig_rxsyncwinszdef; // :582:16
+uint8_t orig_rfrxtmda; // :583:16
+
+/* ======== components/network/ble/blecontroller/ip/ble/ll/src/rwble/rwble.c ======== */
+
+void rwble_init(void); // :87:6
+void rwble_reset(void); // :117:6
+bool rwble_sleep_check(void); // :158:5
+bool rwble_activity_ongoing_check(void); // :164:5
+void rwble_version(uint8_t *fw_version, uint8_t *hw_version); // :175:6
+void rwble_isr_clear(void); // :193:6
+void rwble_isr(void); // :202:6
+
+/* ======== components/network/ble/blecontroller/ip/ea/api/ea.h ======== */
+
+enum ea_error {
+    EA_ERROR_OK = 0,
+    EA_ERROR_REJECTED = 1,
+    EA_ERROR_NOT_FOUND = 2,
+    EA_ERROR_BW_FULL = 3,
+}; // :83:6
+
+enum ea_param_req_action {
+    EA_PARAM_REQ_GET = 0,
+    EA_PARAM_REQ_CHECK = 1,
+}; // :96:6
+
+enum ea_elt_asap_type {
+    EA_FLAG_NO_ASAP = 0,
+    EA_FLAG_ASAP_NO_LIMIT = 1,
+    EA_FLAG_ASAP_LIMIT = 2,
+    EA_FLAG_MAX = 3,
+}; // :103:6
+
+enum ea_elt_asap_parity {
+    EA_EVEN_SLOT = 0,
+    EA_ODD_SLOT = 1,
+    EA_NO_PARITY = 2,
+}; // :115:6
+
+struct ea_elt_tag {
+    struct co_list_hdr hdr;
+    struct ea_elt_tag *linked_element;
+    uint32_t timestamp;
+    uint32_t asap_limit;
+    uint16_t asap_settings;
+    uint16_t duration_min;
+    uint16_t delay;
+    uint8_t current_prio;
+    uint8_t stop_latency1;
+    uint8_t stop_latency2;
+    uint8_t start_latency;
+    void (*ea_cb_start)(struct ea_elt_tag *);
+    void (*ea_cb_stop)(struct ea_elt_tag *);
+    void (*ea_cb_cancel)(struct ea_elt_tag *);
+    void *env;
+}; // :130:8
+
+struct ea_interval_tag {
+    struct co_list_hdr hdr;
+    uint16_t interval_used;
+    uint16_t offset_used;
+    uint16_t bandwidth_used;
+    uint16_t conhdl_used;
+    uint16_t role_used;
+    uint16_t linkid;
+}; // :217:8
+
+struct ea_param_input {
+    uint16_t interval_min;
+    uint16_t interval_max;
+    uint32_t duration_min;
+    uint16_t duration_max;
+    uint8_t pref_period;
+    uint16_t offset;
+    uint8_t action;
+    uint16_t conhdl;
+    uint16_t role;
+    bool odd_offset;
+    uint16_t linkid;
+}; // :236:8
+
+struct ea_param_output {
+    uint16_t interval;
+    uint32_t duration;
+    uint16_t offset;
+}; // :263:8
+
+/* ======== components/network/ble/blecontroller/ip/ea/src/ea.c ======== */
+
+enum ea_conflict {
+    START_BEFORE_END_BEFORE = 0,
+    START_BEFORE_END_DURING = 1,
+    START_BEFORE_END_AFTER = 2,
+    START_DURING_END_DURING = 3,
+    START_DURING_END_AFTER = 4,
+    START_AFTER_END_AFTER = 5,
+}; // :81:6
+
+struct ea_env_tag {
+    struct co_list elt_wait;
+    struct ea_elt_tag *elt_prog;
+    struct co_list elt_canceled;
+    struct co_list interval_list;
+    uint32_t finetarget_time;
+}; // :97:8
+
+static struct ea_env_tag ea_env; // :122:26
+
+static uint8_t ea_conflict_check(struct ea_elt_tag *evt_a, struct ea_elt_tag *evt_b); // :147:16
+void ea_elt_cancel(struct ea_elt_tag *new_elt); // :268:6
+static void ea_prog_timer(void); // :418:13
+void ea_init(bool reset); // :555:6
+struct ea_elt_tag *ea_elt_create(uint16_t size_of_env); // :569:20
+uint8_t ea_elt_insert(struct ea_elt_tag *elt); // :592:9
+uint8_t ea_elt_remove(struct ea_elt_tag *elt); // :980:9
+struct ea_interval_tag *ea_interval_create(void); // :1030:25
+void ea_interval_insert(struct ea_interval_tag *interval_to_add); // :1037:6
+void ea_interval_remove(struct ea_interval_tag *interval_to_remove); // :1042:6
+void ea_interval_delete(struct ea_interval_tag *interval_to_remove); // :1048:6
+void ea_finetimer_isr(void); // :1059:6
+void ea_sw_isr(void); // :1189:6
+uint8_t ea_offset_req(struct ea_param_input *input_param, struct ea_param_output *output_param); // :1207:9
+uint32_t ea_time_get_halfslot_rounded(void); // :1321:10
+uint32_t ea_time_get_slot_rounded(void); // :1340:10
+uint32_t ea_timer_target_get(uint32_t current_time); // :1360:10
+void ea_interval_duration_req(struct ea_param_input *input_param, struct ea_param_output *output_param); // :1379:6
+
+/* ======== components/network/ble/blecontroller/ip/hci/api/hci.h ======== */
+
+enum HCI_MSG {
+    HCI_MSG_ID_FIRST = 2048,
+    HCI_CMD_CMP_EVENT = 2049,
+    HCI_CMD_STAT_EVENT = 2050,
+    HCI_EVENT = 2051,
+    HCI_LE_EVENT = 2052,
+    HCI_COMMAND = 2053,
+    HCI_ACL_DATA_RX = 2054,
+    HCI_ACL_DATA_TX = 2055,
+    HCI_TCI_LMP = 2056,
+    HCI_DBG_EVT = 2057,
+    HCI_MSG_ID_LAST = 2058,
+}; // :80:6
+
+/* ======== components/network/ble/blecontroller/ip/hci/src/hci.c ======== */
+
+static const struct evt_mask hci_def_evt_msk; // :76:30
+static const struct evt_mask hci_rsvd_evt_msk; // :79:30
+struct hci_env_tag hci_env; // :88:20
+
+void hci_init(void); // :721:6
+void hci_reset(void); // :737:6
+void hci_send_2_host(void *param); // :755:6
+void hci_send_2_controller(void *param); // :979:6
+uint8_t hci_evt_mask_set(const struct evt_mask *evt_msk, uint8_t page); // :1128:9
+
+/* ======== components/network/ble/blecontroller/ip/hci/src/hci_fc.c ======== */
+
+struct host_set_fc {
+    bool acl_flow_cntl_en;
+    uint16_t acl_pkt_len;
+    uint16_t acl_pkt_nb;
+    uint16_t curr_pkt_nb;
+}; // :67:8
+
+struct counter_fc {
+    uint16_t acl_pkt_sent;
+}; // :90:8
+
+struct hci_fc_tag {
+    struct host_set_fc host_set;
+    struct counter_fc cntr;
+}; // :102:8
+
+struct hci_fc_tag hci_fc_env; // :122:19
+
+void hci_fc_acl_packet_sent(void); // :236:6
+void hci_fc_host_nb_acl_pkts_complete(uint16_t acl_pkt_nb); // :256:6
+uint16_t hci_fc_check_host_available_nb_acl_packets(void); // :284:10
+
+/* ======== components/network/ble/blecontroller/ip/hci/src/hci_int.h ======== */
+
+enum HCI_MSG_DEST_LL {
+    MNG = 0,
+    CTRL = 1,
+    BLE_MNG = 2,
+    BLE_CTRL = 3,
+    BT_MNG = 4,
+    BT_CTRL_CONHDL = 5,
+    BT_CTRL_BD_ADDR = 6,
+    BT_BCST = 7,
+    DBG = 8,
+    LL_UNDEF = 9,
+}; // :122:6
+
+enum HCI_MSG_DEST_HL {
+    HL_MNG = 0,
+    HL_CTRL = 1,
+    HL_DATA = 2,
+    HL_AM0 = 3,
+    HL_UNDEF = 4,
+}; // :137:6
+
+enum HCI_PACK_STATUS {
+    HCI_PACK_OK = 0,
+    HCI_PACK_IN_BUF_OVFLW = 1,
+    HCI_PACK_OUT_BUF_OVFLW = 2,
+    HCI_PACK_WRONG_FORMAT = 3,
+    HCI_PACK_ERROR = 4,
+}; // :148:6
+
+struct hci_cmd_desc_tab_ref {
+    uint8_t ogf;
+    uint16_t nb_cmds;
+    const struct hci_cmd_desc_tag *cmd_desc_tab;
+}; // :178:8
+
+struct hci_cmd_desc_tag {
+    uint16_t opcode;
+    uint8_t dest_field;
+    uint8_t par_size_max;
+    void *par_fmt;
+    void *ret_par_fmt;
+}; // :191:8
+
+struct hci_evt_desc_tag {
+    uint8_t code;
+    uint8_t dest_field;
+    uint8_t special_pack;
+    void *par_fmt;
+}; // :212:8
+
+typedef uint16_t (*hci_pkupk_func_t)(uint8_t *, uint8_t *, uint16_t *, uint16_t); // :231:20
+
+struct hci_env_tag {
+    struct evt_mask evt_msk;
+    struct evt_mask evt_msk_page_2;
+}; // :288:8
+
+struct hci_env_tag hci_env; // :339:27
+
+/* ======== components/network/ble/blecontroller/ip/hci/src/hci_msg.c ======== */
+
+const struct hci_cmd_desc_tag hci_cmd_desc_tab_lk_ctrl[3]; // :135:31
+const struct hci_cmd_desc_tag hci_cmd_desc_tab_ctrl_bb[10]; // :207:31
+const struct hci_cmd_desc_tag hci_cmd_desc_tab_info_par[5]; // :309:31
+const struct hci_cmd_desc_tag hci_cmd_desc_tab_stat_par[1]; // :323:31
+const struct hci_cmd_desc_tag hci_cmd_desc_tab_le[49]; // :353:31
+const struct hci_cmd_desc_tag hci_cmd_desc_tab_vs[4]; // :446:31
+const struct hci_cmd_desc_tab_ref hci_cmd_desc_root_tab[6]; // :522:35
+const struct hci_evt_desc_tag hci_evt_desc_tab[9]; // :541:31
+const struct hci_evt_desc_tag hci_evt_le_desc_tab[12]; // :628:31
+
+static uint8_t hci_pack_bytes(uint8_t **pp_in, uint8_t **pp_out, uint8_t *p_in_end, uint8_t *p_out_end, uint8_t len); // :679:16
+static uint8_t hci_host_nb_cmp_pkts_cmd_pkupk(uint8_t *out, uint8_t *in, uint16_t *out_len, uint16_t in_len); // :710:16
+static uint8_t hci_le_adv_report_evt_pkupk(uint8_t *out, uint8_t *in, uint16_t *out_len, uint16_t in_len); // :1557:16
+static uint8_t hci_le_dir_adv_report_evt_pkupk(uint8_t *out, uint8_t *in, uint16_t *out_len, uint16_t in_len); // :1849:16
+const struct hci_cmd_desc_tag *hci_look_for_cmd_desc(uint16_t opcode); // :2584:32
+const struct hci_evt_desc_tag *hci_look_for_evt_desc(uint8_t code); // :2637:32
+const struct hci_evt_desc_tag *hci_look_for_le_evt_desc(uint8_t subcode); // :2687:32
+
+/* ======== components/network/ble/blecontroller/ip/hci/src/hci_onchip.c ======== */
+
+static bt_hci_recv_cb hci_rx_cb; // :22:23
+static const struct ke_msg_handler hci_onchip_default_state[5]; // :26:36
+const struct ke_state_handler hci_onchip_default_handler; // :35:31
+static const struct ke_task_desc TASK_DESC_HCI_ONCHIP; // :36:34
+
+uint8_t bt_onchiphci_interface_init(bt_hci_recv_cb cb); // :38:9
+int bt_onchiphci_send(uint8_t pkt_type, ke_task_id_t dest_id, hci_pkt_struct *pkt); // :44:5
+static int bt_hcionchip_recv(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :144:12
+uint8_t bt_onchiphci_hanlde_rx_acl(void *param, uint8_t *host_buf_data); // :191:9
+
+/* ======== components/network/ble/blecontroller/ip/hci/src/hci_tl.c ======== */
+
+enum HCI_TX_STATE {
+    HCI_STATE_TX_ONGOING = 0,
+    HCI_STATE_TX_IDLE = 1,
+}; // :92:6
+
+struct hci_tl_env_tag {
+    struct co_list tx_queue;
+    struct co_list acl_queue;
+    struct ke_msg *curr_tx_msg;
+    struct em_buf_node *txtag;
+    uint8_t tx_state;
+    int8_t nb_h2c_cmd_pkts;
+}; // :107:8
+
+static struct hci_tl_env_tag hci_tl_env; // :154:30
+
+void hci_tl_send(struct ke_msg *msg); // :1221:6
+void hci_tl_init(bool reset); // :1272:6
+uint8_t hci_cmd_get_max_param_size(uint16_t opcode); // :1303:9
+void hci_cmd_received(uint16_t opcode, uint8_t length, uint8_t *payload); // :1319:6
+uint8_t *hci_acl_tx_data_alloc(uint16_t hdl_flags, uint16_t len); // :1530:10
+void hci_acl_tx_data_received(uint16_t hdl_flags, uint16_t datalen, uint8_t *payload); // :1634:6
+
+/* ======== components/network/ble/blecontroller/ip/hci/src/hci_util.c ======== */
+
+static uint16_t hci_util_read_array_size(char **fmt_cursor); // :69:17
+enum HCI_PACK_STATUS hci_util_pack(uint8_t *inout, uint16_t *inout_len, const char *format); // :95:22
+enum HCI_PACK_STATUS hci_util_unpack(uint8_t *out, uint8_t *in, uint16_t *out_len, uint16_t in_len, const char *format); // :226:22
+uint8_t *hci_build_cc_evt(struct ke_msg *msg, int8_t nb_h2c_cmd_pkts); // :392:10
+uint8_t *hci_build_evt(struct ke_msg *msg); // :463:10
+uint8_t *hci_build_le_evt(struct ke_msg *msg); // :525:10
+uint8_t *hci_build_acl_rx_data(struct ke_msg *msg); // :592:10
+
+/* ======== components/network/ble/blecontroller/modules/common/api/co_bt_defines.h ======== */
+
+enum le_evt_mask {
+    LE_CON_CMP_EVT_BIT = 0,
+    LE_CON_CMP_EVT_MSK = 1,
+    LE_ADV_REP_EVT_BIT = 1,
+    LE_ADV_REP_EVT_MSK = 2,
+    LE_CON_UPD_EVT_BIT = 2,
+    LE_CON_UPD_EVT_MSK = 4,
+    LE_CON_RD_REM_FEAT_EVT_BIT = 3,
+    LE_CON_RD_REM_FEAT_EVT_MSK = 8,
+    LE_LG_TR_KEY_REQ_EVT_BIT = 4,
+    LE_LG_TR_KEY_REQ_EVT_MSK = 16,
+    LE_REM_CON_PARA_REQ_EVT_BIT = 5,
+    LE_REM_CON_PARA_REQ_EVT_MSK = 32,
+    LE_DATA_LEN_CHG_EVT_BIT = 6,
+    LE_DATA_LEN_CHG_EVT_MSK = 64,
+    LE_RD_LOC_P256_PUB_KEY_CMP_EVT_BIT = 7,
+    LE_RD_LOC_P256_PUB_KEY_CMP_EVT_MSK = 128,
+    LE_GEN_DHKEY_CMP_EVT_BIT = 8,
+    LE_GEN_DHKEY_CMP_EVT_MSK = 256,
+    LE_ENH_CON_CMP_EVT_BIT = 9,
+    LE_ENH_CON_CMP_EVT_MSK = 512,
+    LE_DIR_ADV_REP_EVT_BIT = 10,
+    LE_DIR_ADV_REP_EVT_MSK = 1024,
+    LE_PHY_UPD_CMP_EVT_BIT = 11,
+    LE_PHY_UPD_CMP_EVT_MSK = 2048,
+    LE_EXT_ADV_REP_EVT_BIT = 12,
+    LE_EXT_ADV_REP_EVT_MSK = 4096,
+    LE_PER_ADV_SYNC_EST_EVT_BIT = 13,
+    LE_PER_ADV_SYNC_EST_EVT_MSK = 8192,
+    LE_PER_ADV_REP_EVT_BIT = 14,
+    LE_PER_ADV_REP_EVT_MSK = 16384,
+    LE_PER_ADV_SYNC_LOST_EVT_BIT = 15,
+    LE_PER_ADV_SYNC_LOST_EVT_MSK = 32768,
+    LE_EXT_SCAN_TO_EVT_BIT = 16,
+    LE_EXT_SCAN_TO_EVT_MSK = 65536,
+    LE_EXT_ADV_SET_TER_EVT_BIT = 17,
+    LE_EXT_ADV_SET_TER_EVT_MSK = 131072,
+    LE_SCAN_REQ_REC_EVT_BIT = 18,
+    LE_SCAN_REQ_REC_EVT_MSK = 262144,
+    LE_CH_SEL_ALGO_EVT_BIT = 19,
+    LE_CH_SEL_ALGO_EVT_MSK = 524288,
+    LE_DFT_EVT_MSK = 31,
+}; // :1330:6
+
+enum rnd_addr_type {
+    RND_STATIC_ADDR = 192,
+    RND_NON_RSLV_ADDR = 0,
+    RND_RSLV_ADDR = 64,
+}; // :1646:6
+
+enum adv_channel_map {
+    ADV_CHNL_37_EN = 1,
+    ADV_CHNL_38_EN = 2,
+    ADV_CHNL_39_EN = 4,
+    ADV_ALL_CHNLS_EN = 7,
+    ADV_CHNL_END = 8,
+}; // :1657:6
+
+enum adv_filter_policy {
+    ADV_ALLOW_SCAN_ANY_CON_ANY = 0,
+    ADV_ALLOW_SCAN_WLST_CON_ANY = 1,
+    ADV_ALLOW_SCAN_ANY_CON_WLST = 2,
+    ADV_ALLOW_SCAN_WLST_CON_WLST = 3,
+    ADV_ALLOW_SCAN_END = 4,
+}; // :1672:6
+
+enum scan_filter_policy {
+    SCAN_ALLOW_ADV_ALL = 0,
+    SCAN_ALLOW_ADV_WLST = 1,
+    SCAN_ALLOW_ADV_ALL_AND_INIT_RPA = 2,
+    SCAN_ALLOW_ADV_WLST_AND_INIT_RPA = 3,
+    SCAN_ALLOW_ADV_END = 4,
+}; // :1709:6
+
+enum scan_dup_filter_policy {
+    SCAN_FILT_DUPLIC_DIS = 0,
+    SCAN_FILT_DUPLIC_EN = 1,
+    SCAN_FILT_DUPLIC_END = 2,
+}; // :1735:6
+
+struct evt_mask {
+    uint8_t mask[8];
+}; // :1928:8
+
+struct bd_addr {
+    uint8_t addr[6];
+}; // :1944:8
+
+struct back_packet_info {
+    uint8_t used;
+    uint8_t advmode_headlen;
+    uint8_t head_flags;
+    struct bd_addr adva_addr;
+    struct bd_addr targeta_addr;
+    uint16_t adi;
+    uint8_t auxptr[3];
+    uint8_t syncinfo[18];
+    uint8_t txpwr;
+    uint8_t datalen;
+    uint8_t data[255];
+}; // :1951:8
+
+struct access_addr {
+    uint8_t addr[4];
+}; // :1968:8
+
+struct adv_data {
+    uint8_t data[31];
+}; // :1975:8
+
+struct scan_rsp_data {
+    uint8_t data[31];
+}; // :1988:8
+
+struct le_chnl_map {
+    uint8_t map[5];
+}; // :2010:8
+
+struct ltk {
+    uint8_t ltk[16];
+}; // :2017:8
+
+struct rand_nb {
+    uint8_t nb[8];
+}; // :2047:8
+
+struct adv_report {
+    uint8_t evt_type;
+    uint8_t adv_addr_type;
+    struct bd_addr adv_addr;
+    uint8_t data_len;
+    uint8_t data[31];
+    uint8_t rssi;
+}; // :2054:8
+
+struct dir_adv_report {
+    uint8_t evt_type;
+    uint8_t addr_type;
+    struct bd_addr addr;
+    uint8_t dir_addr_type;
+    struct bd_addr dir_addr;
+    uint8_t rssi;
+}; // :2111:8
+
+struct le_features {
+    uint8_t feats[8];
+}; // :2129:8
+
+struct features {
+    uint8_t feats[8];
+}; // :2186:8
+
+struct supp_cmds {
+    uint8_t cmds[64];
+}; // :2193:8
+
+struct le_states {
+    uint8_t supp_states[8];
+}; // :2248:8
+
+struct crc_init {
+    uint8_t crc[3];
+}; // :2264:8
+
+struct sess_k_div_x {
+    uint8_t skdiv[8];
+}; // :2271:8
+
+struct sess_k_div {
+    uint8_t skd[16];
+}; // :2278:8
+
+struct init_vect {
+    uint8_t iv[4];
+}; // :2285:8
+
+struct t_public_key {
+    uint8_t x[32];
+    uint8_t y[32];
+}; // :2291:16
+
+typedef struct t_public_key t_public_key; // :2296:3
+
+/* ======== components/network/ble/blecontroller/modules/common/api/co_error.h ======== */
+
+enum co_error {
+    CO_ERROR_NO_ERROR = 0,
+    CO_ERROR_UNKNOWN_HCI_COMMAND = 1,
+    CO_ERROR_UNKNOWN_CONNECTION_ID = 2,
+    CO_ERROR_HARDWARE_FAILURE = 3,
+    CO_ERROR_PAGE_TIMEOUT = 4,
+    CO_ERROR_AUTH_FAILURE = 5,
+    CO_ERROR_PIN_MISSING = 6,
+    CO_ERROR_MEMORY_CAPA_EXCEED = 7,
+    CO_ERROR_CON_TIMEOUT = 8,
+    CO_ERROR_CON_LIMIT_EXCEED = 9,
+    CO_ERROR_SYNC_CON_LIMIT_DEV_EXCEED = 10,
+    CO_ERROR_ACL_CON_EXISTS = 11,
+    CO_ERROR_COMMAND_DISALLOWED = 12,
+    CO_ERROR_CONN_REJ_LIMITED_RESOURCES = 13,
+    CO_ERROR_CONN_REJ_SECURITY_REASONS = 14,
+    CO_ERROR_CONN_REJ_UNACCEPTABLE_BDADDR = 15,
+    CO_ERROR_CONN_ACCEPT_TIMEOUT_EXCEED = 16,
+    CO_ERROR_UNSUPPORTED = 17,
+    CO_ERROR_INVALID_HCI_PARAM = 18,
+    CO_ERROR_REMOTE_USER_TERM_CON = 19,
+    CO_ERROR_REMOTE_DEV_TERM_LOW_RESOURCES = 20,
+    CO_ERROR_REMOTE_DEV_POWER_OFF = 21,
+    CO_ERROR_CON_TERM_BY_LOCAL_HOST = 22,
+    CO_ERROR_REPEATED_ATTEMPTS = 23,
+    CO_ERROR_PAIRING_NOT_ALLOWED = 24,
+    CO_ERROR_UNKNOWN_LMP_PDU = 25,
+    CO_ERROR_UNSUPPORTED_REMOTE_FEATURE = 26,
+    CO_ERROR_SCO_OFFSET_REJECTED = 27,
+    CO_ERROR_SCO_INTERVAL_REJECTED = 28,
+    CO_ERROR_SCO_AIR_MODE_REJECTED = 29,
+    CO_ERROR_INVALID_LMP_PARAM = 30,
+    CO_ERROR_UNSPECIFIED_ERROR = 31,
+    CO_ERROR_UNSUPPORTED_LMP_PARAM_VALUE = 32,
+    CO_ERROR_ROLE_CHANGE_NOT_ALLOWED = 33,
+    CO_ERROR_LMP_RSP_TIMEOUT = 34,
+    CO_ERROR_LMP_COLLISION = 35,
+    CO_ERROR_LMP_PDU_NOT_ALLOWED = 36,
+    CO_ERROR_ENC_MODE_NOT_ACCEPT = 37,
+    CO_ERROR_LINK_KEY_CANT_CHANGE = 38,
+    CO_ERROR_QOS_NOT_SUPPORTED = 39,
+    CO_ERROR_INSTANT_PASSED = 40,
+    CO_ERROR_PAIRING_WITH_UNIT_KEY_NOT_SUP = 41,
+    CO_ERROR_DIFF_TRANSACTION_COLLISION = 42,
+    CO_ERROR_QOS_UNACCEPTABLE_PARAM = 44,
+    CO_ERROR_QOS_REJECTED = 45,
+    CO_ERROR_CHANNEL_CLASS_NOT_SUP = 46,
+    CO_ERROR_INSUFFICIENT_SECURITY = 47,
+    CO_ERROR_PARAM_OUT_OF_MAND_RANGE = 48,
+    CO_ERROR_ROLE_SWITCH_PEND = 50,
+    CO_ERROR_RESERVED_SLOT_VIOLATION = 52,
+    CO_ERROR_ROLE_SWITCH_FAIL = 53,
+    CO_ERROR_EIR_TOO_LARGE = 54,
+    CO_ERROR_SP_NOT_SUPPORTED_HOST = 55,
+    CO_ERROR_HOST_BUSY_PAIRING = 56,
+    CO_ERROR_CONTROLLER_BUSY = 58,
+    CO_ERROR_UNACCEPTABLE_CONN_INT = 59,
+    CO_ERROR_DIRECT_ADV_TO = 60,
+    CO_ERROR_TERMINATED_MIC_FAILURE = 61,
+    CO_ERROR_CONN_FAILED_TO_BE_EST = 62,
+    CO_ERROR_CCA_REJ_USE_CLOCK_DRAG = 64,
+    CO_ERROR_UNKNOW_ADV_ID = 66,
+    CO_ERROR_LIMIT_REACHED = 67,
+    CO_ERROR_OP_CANCELL_BY_HOST = 68,
+    CO_ERROR_UNDEFINED = 255,
+    CO_ERROR_HW_UART_OUT_OF_SYNC = 0,
+    CO_ERROR_HW_MEM_ALLOC_FAIL = 1,
+}; // :31:6
+
+/* ======== components/network/ble/blecontroller/modules/common/api/co_hci.h ======== */
+
+enum hci_opcode {
+    HCI_NO_OPERATION_CMD_OPCODE = 0,
+    HCI_INQ_CMD_OPCODE = 1025,
+    HCI_INQ_CANCEL_CMD_OPCODE = 1026,
+    HCI_PER_INQ_MODE_CMD_OPCODE = 1027,
+    HCI_EXIT_PER_INQ_MODE_CMD_OPCODE = 1028,
+    HCI_CREATE_CON_CMD_OPCODE = 1029,
+    HCI_DISCONNECT_CMD_OPCODE = 1030,
+    HCI_CREATE_CON_CANCEL_CMD_OPCODE = 1032,
+    HCI_ACCEPT_CON_REQ_CMD_OPCODE = 1033,
+    HCI_REJECT_CON_REQ_CMD_OPCODE = 1034,
+    HCI_LK_REQ_REPLY_CMD_OPCODE = 1035,
+    HCI_LK_REQ_NEG_REPLY_CMD_OPCODE = 1036,
+    HCI_PIN_CODE_REQ_REPLY_CMD_OPCODE = 1037,
+    HCI_PIN_CODE_REQ_NEG_REPLY_CMD_OPCODE = 1038,
+    HCI_CHG_CON_PKT_TYPE_CMD_OPCODE = 1039,
+    HCI_AUTH_REQ_CMD_OPCODE = 1041,
+    HCI_SET_CON_ENC_CMD_OPCODE = 1043,
+    HCI_CHG_CON_LK_CMD_OPCODE = 1045,
+    HCI_MASTER_LK_CMD_OPCODE = 1047,
+    HCI_REM_NAME_REQ_CMD_OPCODE = 1049,
+    HCI_REM_NAME_REQ_CANCEL_CMD_OPCODE = 1050,
+    HCI_RD_REM_SUPP_FEATS_CMD_OPCODE = 1051,
+    HCI_RD_REM_EXT_FEATS_CMD_OPCODE = 1052,
+    HCI_RD_REM_VER_INFO_CMD_OPCODE = 1053,
+    HCI_RD_CLK_OFF_CMD_OPCODE = 1055,
+    HCI_RD_LMP_HDL_CMD_OPCODE = 1056,
+    HCI_SETUP_SYNC_CON_CMD_OPCODE = 1064,
+    HCI_ACCEPT_SYNC_CON_REQ_CMD_OPCODE = 1065,
+    HCI_REJECT_SYNC_CON_REQ_CMD_OPCODE = 1066,
+    HCI_IO_CAP_REQ_REPLY_CMD_OPCODE = 1067,
+    HCI_USER_CFM_REQ_REPLY_CMD_OPCODE = 1068,
+    HCI_USER_CFM_REQ_NEG_REPLY_CMD_OPCODE = 1069,
+    HCI_USER_PASSKEY_REQ_REPLY_CMD_OPCODE = 1070,
+    HCI_USER_PASSKEY_REQ_NEG_REPLY_CMD_OPCODE = 1071,
+    HCI_REM_OOB_DATA_REQ_REPLY_CMD_OPCODE = 1072,
+    HCI_REM_OOB_DATA_REQ_NEG_REPLY_CMD_OPCODE = 1075,
+    HCI_IO_CAP_REQ_NEG_REPLY_CMD_OPCODE = 1076,
+    HCI_ENH_SETUP_SYNC_CON_CMD_OPCODE = 1085,
+    HCI_ENH_ACCEPT_SYNC_CON_CMD_OPCODE = 1086,
+    HCI_TRUNC_PAGE_CMD_OPCODE = 1087,
+    HCI_TRUNC_PAGE_CAN_CMD_OPCODE = 1088,
+    HCI_SET_CON_SLV_BCST_CMD_OPCODE = 1089,
+    HCI_SET_CON_SLV_BCST_REC_CMD_OPCODE = 1090,
+    HCI_START_SYNC_TRAIN_CMD_OPCODE = 1091,
+    HCI_REC_SYNC_TRAIN_CMD_OPCODE = 1092,
+    HCI_REM_OOB_EXT_DATA_REQ_REPLY_CMD_OPCODE = 1093,
+    HCI_HOLD_MODE_CMD_OPCODE = 2049,
+    HCI_SNIFF_MODE_CMD_OPCODE = 2051,
+    HCI_EXIT_SNIFF_MODE_CMD_OPCODE = 2052,
+    HCI_PARK_STATE_CMD_OPCODE = 2053,
+    HCI_EXIT_PARK_STATE_CMD_OPCODE = 2054,
+    HCI_QOS_SETUP_CMD_OPCODE = 2055,
+    HCI_ROLE_DISCOVERY_CMD_OPCODE = 2057,
+    HCI_SWITCH_ROLE_CMD_OPCODE = 2059,
+    HCI_RD_LINK_POL_STG_CMD_OPCODE = 2060,
+    HCI_WR_LINK_POL_STG_CMD_OPCODE = 2061,
+    HCI_RD_DFT_LINK_POL_STG_CMD_OPCODE = 2062,
+    HCI_WR_DFT_LINK_POL_STG_CMD_OPCODE = 2063,
+    HCI_FLOW_SPEC_CMD_OPCODE = 2064,
+    HCI_SNIFF_SUB_CMD_OPCODE = 2065,
+    HCI_SET_EVT_MASK_CMD_OPCODE = 3073,
+    HCI_RESET_CMD_OPCODE = 3075,
+    HCI_SET_EVT_FILTER_CMD_OPCODE = 3077,
+    HCI_FLUSH_CMD_OPCODE = 3080,
+    HCI_RD_PIN_TYPE_CMD_OPCODE = 3081,
+    HCI_WR_PIN_TYPE_CMD_OPCODE = 3082,
+    HCI_CREATE_NEW_UNIT_KEY_CMD_OPCODE = 3083,
+    HCI_RD_STORED_LK_CMD_OPCODE = 3085,
+    HCI_WR_STORED_LK_CMD_OPCODE = 3089,
+    HCI_DEL_STORED_LK_CMD_OPCODE = 3090,
+    HCI_WR_LOCAL_NAME_CMD_OPCODE = 3091,
+    HCI_RD_LOCAL_NAME_CMD_OPCODE = 3092,
+    HCI_RD_CON_ACCEPT_TO_CMD_OPCODE = 3093,
+    HCI_WR_CON_ACCEPT_TO_CMD_OPCODE = 3094,
+    HCI_RD_PAGE_TO_CMD_OPCODE = 3095,
+    HCI_WR_PAGE_TO_CMD_OPCODE = 3096,
+    HCI_RD_SCAN_EN_CMD_OPCODE = 3097,
+    HCI_WR_SCAN_EN_CMD_OPCODE = 3098,
+    HCI_RD_PAGE_SCAN_ACT_CMD_OPCODE = 3099,
+    HCI_WR_PAGE_SCAN_ACT_CMD_OPCODE = 3100,
+    HCI_RD_INQ_SCAN_ACT_CMD_OPCODE = 3101,
+    HCI_WR_INQ_SCAN_ACT_CMD_OPCODE = 3102,
+    HCI_RD_AUTH_EN_CMD_OPCODE = 3103,
+    HCI_WR_AUTH_EN_CMD_OPCODE = 3104,
+    HCI_RD_CLASS_OF_DEV_CMD_OPCODE = 3107,
+    HCI_WR_CLASS_OF_DEV_CMD_OPCODE = 3108,
+    HCI_RD_VOICE_STG_CMD_OPCODE = 3109,
+    HCI_WR_VOICE_STG_CMD_OPCODE = 3110,
+    HCI_RD_AUTO_FLUSH_TO_CMD_OPCODE = 3111,
+    HCI_WR_AUTO_FLUSH_TO_CMD_OPCODE = 3112,
+    HCI_RD_NB_BDCST_RETX_CMD_OPCODE = 3113,
+    HCI_WR_NB_BDCST_RETX_CMD_OPCODE = 3114,
+    HCI_RD_HOLD_MODE_ACTIVITY_CMD_OPCODE = 3115,
+    HCI_WR_HOLD_MODE_ACTIVITY_CMD_OPCODE = 3116,
+    HCI_RD_TX_PWR_LVL_CMD_OPCODE = 3117,
+    HCI_RD_SYNC_FLOW_CTRL_EN_CMD_OPCODE = 3118,
+    HCI_WR_SYNC_FLOW_CTRL_EN_CMD_OPCODE = 3119,
+    HCI_SET_CTRL_TO_HOST_FLOW_CTRL_CMD_OPCODE = 3121,
+    HCI_HOST_BUF_SIZE_CMD_OPCODE = 3123,
+    HCI_HOST_NB_CMP_PKTS_CMD_OPCODE = 3125,
+    HCI_RD_LINK_SUPV_TO_CMD_OPCODE = 3126,
+    HCI_WR_LINK_SUPV_TO_CMD_OPCODE = 3127,
+    HCI_RD_NB_SUPP_IAC_CMD_OPCODE = 3128,
+    HCI_RD_CURR_IAC_LAP_CMD_OPCODE = 3129,
+    HCI_WR_CURR_IAC_LAP_CMD_OPCODE = 3130,
+    HCI_SET_AFH_HOST_CH_CLASS_CMD_OPCODE = 3135,
+    HCI_RD_INQ_SCAN_TYPE_CMD_OPCODE = 3138,
+    HCI_WR_INQ_SCAN_TYPE_CMD_OPCODE = 3139,
+    HCI_RD_INQ_MODE_CMD_OPCODE = 3140,
+    HCI_WR_INQ_MODE_CMD_OPCODE = 3141,
+    HCI_RD_PAGE_SCAN_TYPE_CMD_OPCODE = 3142,
+    HCI_WR_PAGE_SCAN_TYPE_CMD_OPCODE = 3143,
+    HCI_RD_AFH_CH_ASSESS_MODE_CMD_OPCODE = 3144,
+    HCI_WR_AFH_CH_ASSESS_MODE_CMD_OPCODE = 3145,
+    HCI_RD_EXT_INQ_RSP_CMD_OPCODE = 3153,
+    HCI_WR_EXT_INQ_RSP_CMD_OPCODE = 3154,
+    HCI_REFRESH_ENC_KEY_CMD_OPCODE = 3155,
+    HCI_RD_SP_MODE_CMD_OPCODE = 3157,
+    HCI_WR_SP_MODE_CMD_OPCODE = 3158,
+    HCI_RD_LOC_OOB_DATA_CMD_OPCODE = 3159,
+    HCI_RD_INQ_RSP_TX_PWR_LVL_CMD_OPCODE = 3160,
+    HCI_WR_INQ_TX_PWR_LVL_CMD_OPCODE = 3161,
+    HCI_RD_DFT_ERR_DATA_REP_CMD_OPCODE = 3162,
+    HCI_WR_DFT_ERR_DATA_REP_CMD_OPCODE = 3163,
+    HCI_ENH_FLUSH_CMD_OPCODE = 3167,
+    HCI_SEND_KEYPRESS_NOTIF_CMD_OPCODE = 3168,
+    HCI_SET_EVT_MASK_PAGE_2_CMD_OPCODE = 3171,
+    HCI_RD_FLOW_CNTL_MODE_CMD_OPCODE = 3174,
+    HCI_WR_FLOW_CNTL_MODE_CMD_OPCODE = 3175,
+    HCI_RD_ENH_TX_PWR_LVL_CMD_OPCODE = 3176,
+    HCI_RD_LE_HOST_SUPP_CMD_OPCODE = 3180,
+    HCI_WR_LE_HOST_SUPP_CMD_OPCODE = 3181,
+    HCI_SET_MWS_CHANNEL_PARAMS_CMD_OPCODE = 3182,
+    HCI_SET_EXTERNAL_FRAME_CONFIG_CMD_OPCODE = 3183,
+    HCI_SET_MWS_SIGNALING_CMD_OPCODE = 3184,
+    HCI_SET_MWS_TRANSPORT_LAYER_CMD_OPCODE = 3185,
+    HCI_SET_MWS_SCAN_FREQ_TABLE_CMD_OPCODE = 3186,
+    HCI_SET_MWS_PATTERN_CONFIG_CMD_OPCODE = 3187,
+    HCI_SET_RES_LT_ADDR_CMD_OPCODE = 3188,
+    HCI_DEL_RES_LT_ADDR_CMD_OPCODE = 3189,
+    HCI_SET_CON_SLV_BCST_DATA_CMD_OPCODE = 3190,
+    HCI_RD_SYNC_TRAIN_PARAM_CMD_OPCODE = 3191,
+    HCI_WR_SYNC_TRAIN_PARAM_CMD_OPCODE = 3192,
+    HCI_RD_SEC_CON_HOST_SUPP_CMD_OPCODE = 3193,
+    HCI_WR_SEC_CON_HOST_SUPP_CMD_OPCODE = 3194,
+    HCI_RD_AUTH_PAYL_TO_CMD_OPCODE = 3195,
+    HCI_WR_AUTH_PAYL_TO_CMD_OPCODE = 3196,
+    HCI_RD_LOC_OOB_EXT_DATA_CMD_OPCODE = 3197,
+    HCI_RD_EXT_PAGE_TO_CMD_OPCODE = 3198,
+    HCI_WR_EXT_PAGE_TO_CMD_OPCODE = 3199,
+    HCI_RD_EXT_INQ_LEN_CMD_OPCODE = 3200,
+    HCI_WR_EXT_INQ_LEN_CMD_OPCODE = 3201,
+    HCI_RD_LOCAL_VER_INFO_CMD_OPCODE = 4097,
+    HCI_RD_LOCAL_SUPP_CMDS_CMD_OPCODE = 4098,
+    HCI_RD_LOCAL_SUPP_FEATS_CMD_OPCODE = 4099,
+    HCI_RD_LOCAL_EXT_FEATS_CMD_OPCODE = 4100,
+    HCI_RD_BUFF_SIZE_CMD_OPCODE = 4101,
+    HCI_RD_BD_ADDR_CMD_OPCODE = 4105,
+    HCI_RD_LOCAL_SUPP_CODECS_CMD_OPCODE = 4107,
+    HCI_RD_FAIL_CONTACT_CNT_CMD_OPCODE = 5121,
+    HCI_RST_FAIL_CONTACT_CNT_CMD_OPCODE = 5122,
+    HCI_RD_LINK_QUAL_CMD_OPCODE = 5123,
+    HCI_RD_RSSI_CMD_OPCODE = 5125,
+    HCI_RD_AFH_CH_MAP_CMD_OPCODE = 5126,
+    HCI_RD_CLK_CMD_OPCODE = 5127,
+    HCI_RD_ENC_KEY_SIZE_CMD_OPCODE = 5128,
+    HCI_GET_MWS_TRANSPORT_LAYER_CONFIG_CMD_OPCODE = 5132,
+    HCI_RD_LOOPBACK_MODE_CMD_OPCODE = 6145,
+    HCI_WR_LOOPBACK_MODE_CMD_OPCODE = 6146,
+    HCI_EN_DUT_MODE_CMD_OPCODE = 6147,
+    HCI_WR_SP_DBG_MODE_CMD_OPCODE = 6148,
+    HCI_WR_SEC_CON_TEST_MODE_CMD_OPCODE = 6154,
+    HCI_LE_SET_EVT_MASK_CMD_OPCODE = 8193,
+    HCI_LE_RD_BUFF_SIZE_CMD_OPCODE = 8194,
+    HCI_LE_RD_LOCAL_SUPP_FEATS_CMD_OPCODE = 8195,
+    HCI_LE_SET_RAND_ADDR_CMD_OPCODE = 8197,
+    HCI_LE_SET_ADV_PARAM_CMD_OPCODE = 8198,
+    HCI_LE_RD_ADV_CHNL_TX_PW_CMD_OPCODE = 8199,
+    HCI_LE_SET_ADV_DATA_CMD_OPCODE = 8200,
+    HCI_LE_SET_SCAN_RSP_DATA_CMD_OPCODE = 8201,
+    HCI_LE_SET_ADV_EN_CMD_OPCODE = 8202,
+    HCI_LE_SET_SCAN_PARAM_CMD_OPCODE = 8203,
+    HCI_LE_SET_SCAN_EN_CMD_OPCODE = 8204,
+    HCI_LE_CREATE_CON_CMD_OPCODE = 8205,
+    HCI_LE_CREATE_CON_CANCEL_CMD_OPCODE = 8206,
+    HCI_LE_RD_WLST_SIZE_CMD_OPCODE = 8207,
+    HCI_LE_CLEAR_WLST_CMD_OPCODE = 8208,
+    HCI_LE_ADD_DEV_TO_WLST_CMD_OPCODE = 8209,
+    HCI_LE_RMV_DEV_FROM_WLST_CMD_OPCODE = 8210,
+    HCI_LE_CON_UPDATE_CMD_OPCODE = 8211,
+    HCI_LE_SET_HOST_CH_CLASS_CMD_OPCODE = 8212,
+    HCI_LE_RD_CHNL_MAP_CMD_OPCODE = 8213,
+    HCI_LE_RD_REM_USED_FEATS_CMD_OPCODE = 8214,
+    HCI_LE_ENC_CMD_OPCODE = 8215,
+    HCI_LE_RAND_CMD_OPCODE = 8216,
+    HCI_LE_START_ENC_CMD_OPCODE = 8217,
+    HCI_LE_LTK_REQ_REPLY_CMD_OPCODE = 8218,
+    HCI_LE_LTK_REQ_NEG_REPLY_CMD_OPCODE = 8219,
+    HCI_LE_RD_SUPP_STATES_CMD_OPCODE = 8220,
+    HCI_LE_RX_TEST_CMD_OPCODE = 8221,
+    HCI_LE_TX_TEST_CMD_OPCODE = 8222,
+    HCI_LE_TEST_END_CMD_OPCODE = 8223,
+    HCI_LE_REM_CON_PARAM_REQ_REPLY_CMD_OPCODE = 8224,
+    HCI_LE_REM_CON_PARAM_REQ_NEG_REPLY_CMD_OPCODE = 8225,
+    HCI_LE_SET_DATA_LEN_CMD_OPCODE = 8226,
+    HCI_LE_RD_SUGGTED_DFT_DATA_LEN_CMD_OPCODE = 8227,
+    HCI_LE_WR_SUGGTED_DFT_DATA_LEN_CMD_OPCODE = 8228,
+    HCI_LE_RD_LOC_P256_PUB_KEY_CMD_OPCODE = 8229,
+    HCI_LE_GEN_DHKEY_CMD_OPCODE = 8230,
+    HCI_LE_ADD_DEV_TO_RSLV_LIST_CMD_OPCODE = 8231,
+    HCI_LE_RMV_DEV_FROM_RSLV_LIST_CMD_OPCODE = 8232,
+    HCI_LE_CLEAR_RSLV_LIST_CMD_OPCODE = 8233,
+    HCI_LE_RD_RSLV_LIST_SIZE_CMD_OPCODE = 8234,
+    HCI_LE_RD_PEER_RSLV_ADDR_CMD_OPCODE = 8235,
+    HCI_LE_RD_LOC_RSLV_ADDR_CMD_OPCODE = 8236,
+    HCI_LE_SET_ADDR_RESOL_EN_CMD_OPCODE = 8237,
+    HCI_LE_SET_RSLV_PRIV_ADDR_TO_CMD_OPCODE = 8238,
+    HCI_LE_RD_MAX_DATA_LEN_CMD_OPCODE = 8239,
+    HCI_LE_RD_TRANS_PWR_CMD_OPCODE = 8267,
+    HCI_LE_RD_RFPATH_CPS_CMD_OPCODE = 8268,
+    HCI_LE_WR_RFPATH_CPS_CMD_OPCODE = 8269,
+    HCI_DBG_RD_MEM_CMD_OPCODE = 64513,
+    HCI_DBG_WR_MEM_CMD_OPCODE = 64514,
+    HCI_DBG_DEL_PAR_CMD_OPCODE = 64515,
+    HCI_DBG_ID_FLASH_CMD_OPCODE = 64517,
+    HCI_DBG_ER_FLASH_CMD_OPCODE = 64518,
+    HCI_DBG_WR_FLASH_CMD_OPCODE = 64519,
+    HCI_DBG_RD_FLASH_CMD_OPCODE = 64520,
+    HCI_DBG_RD_PAR_CMD_OPCODE = 64521,
+    HCI_DBG_WR_PAR_CMD_OPCODE = 64522,
+    HCI_DBG_WLAN_COEX_CMD_OPCODE = 64523,
+    HCI_DBG_WLAN_COEXTST_SCEN_CMD_OPCODE = 64525,
+    HCI_DBG_BT_SEND_LMP_CMD_OPCODE = 64526,
+    HCI_DBG_SET_LOCAL_CLOCK_CMD_OPCODE = 64527,
+    HCI_DBG_RD_KE_STATS_CMD_OPCODE = 64528,
+    HCI_DBG_PLF_RESET_CMD_OPCODE = 64529,
+    HCI_DBG_RD_MEM_INFO_CMD_OPCODE = 64530,
+    HCI_DBG_HW_REG_RD_CMD_OPCODE = 64560,
+    HCI_DBG_HW_REG_WR_CMD_OPCODE = 64561,
+    HCI_DBG_SET_BD_ADDR_CMD_OPCODE = 64562,
+    HCI_DBG_SET_TYPE_PUB_CMD_OPCODE = 64563,
+    HCI_DBG_SET_TYPE_RAND_CMD_OPCODE = 64564,
+    HCI_DBG_SET_CRC_CMD_OPCODE = 64565,
+    HCI_DBG_LLCP_DISCARD_CMD_OPCODE = 64566,
+    HCI_DBG_RESET_RX_CNT_CMD_OPCODE = 64567,
+    HCI_DBG_RESET_TX_CNT_CMD_OPCODE = 64568,
+    HCI_DBG_RF_REG_RD_CMD_OPCODE = 64569,
+    HCI_DBG_RF_REG_WR_CMD_OPCODE = 64570,
+    HCI_DBG_SET_TX_PW_CMD_OPCODE = 64571,
+    HCI_DBG_RF_SWITCH_CLK_CMD_OPCODE = 64572,
+    HCI_DBG_RF_WR_DATA_TX_CMD_OPCODE = 64573,
+    HCI_DBG_RF_RD_DATA_RX_CMD_OPCODE = 64574,
+    HCI_DBG_RF_CNTL_TX_CMD_OPCODE = 64575,
+    HCI_DBG_RF_SYNC_P_CNTL_CMD_OPCODE = 64576,
+    HCI_TESTER_SET_LE_PARAMS_CMD_OPCODE = 64576,
+    HCI_DBG_WR_DLE_DFT_VALUE_CMD_OPCODE = 64577,
+    HCI_DBG_BLE_TST_LLCP_PT_EN_CMD_OPCODE = 64578,
+    HCI_DBG_BLE_TST_SEND_LLCP_CMD_OPCODE = 64579,
+    HCI_VS_AUDIO_ALLOCATE_CMD_OPCODE = 64592,
+    HCI_VS_AUDIO_CONFIGURE_CMD_OPCODE = 64593,
+    HCI_VS_AUDIO_SET_MODE_CMD_OPCODE = 64594,
+    HCI_VS_AUDIO_RESET_CMD_OPCODE = 64595,
+    HCI_VS_AUDIO_SET_POINTER_CMD_OPCODE = 64596,
+    HCI_VS_AUDIO_GET_BUFFER_RANGE_CMD_OPCODE = 64597,
+    HCI_DBG_MWS_COEX_CMD_OPCODE = 64581,
+    HCI_DBG_MWS_COEXTST_SCEN_CMD_OPCODE = 64582,
+    HCI_SET_TX_PWR_CMD_OPCODE = 64609,
+}; // :197:6
+
+enum hci_evt_code {
+    HCI_INQ_CMP_EVT_CODE = 1,
+    HCI_INQ_RES_EVT_CODE = 2,
+    HCI_CON_CMP_EVT_CODE = 3,
+    HCI_CON_REQ_EVT_CODE = 4,
+    HCI_DISC_CMP_EVT_CODE = 5,
+    HCI_AUTH_CMP_EVT_CODE = 6,
+    HCI_REM_NAME_REQ_CMP_EVT_CODE = 7,
+    HCI_ENC_CHG_EVT_CODE = 8,
+    HCI_CHG_CON_LK_CMP_EVT_CODE = 9,
+    HCI_MASTER_LK_CMP_EVT_CODE = 10,
+    HCI_RD_REM_SUPP_FEATS_CMP_EVT_CODE = 11,
+    HCI_RD_REM_VER_INFO_CMP_EVT_CODE = 12,
+    HCI_QOS_SETUP_CMP_EVT_CODE = 13,
+    HCI_CMD_CMP_EVT_CODE = 14,
+    HCI_CMD_STATUS_EVT_CODE = 15,
+    HCI_HW_ERR_EVT_CODE = 16,
+    HCI_FLUSH_OCCURRED_EVT_CODE = 17,
+    HCI_ROLE_CHG_EVT_CODE = 18,
+    HCI_NB_CMP_PKTS_EVT_CODE = 19,
+    HCI_MODE_CHG_EVT_CODE = 20,
+    HCI_RETURN_LINK_KEYS_EVT_CODE = 21,
+    HCI_PIN_CODE_REQ_EVT_CODE = 22,
+    HCI_LK_REQ_EVT_CODE = 23,
+    HCI_LK_NOTIF_EVT_CODE = 24,
+    HCI_DATA_BUF_OVFLW_EVT_CODE = 26,
+    HCI_MAX_SLOT_CHG_EVT_CODE = 27,
+    HCI_RD_CLK_OFF_CMP_EVT_CODE = 28,
+    HCI_CON_PKT_TYPE_CHG_EVT_CODE = 29,
+    HCI_QOS_VIOL_EVT_CODE = 30,
+    HCI_PAGE_SCAN_REPET_MODE_CHG_EVT_CODE = 32,
+    HCI_FLOW_SPEC_CMP_EVT_CODE = 33,
+    HCI_INQ_RES_WITH_RSSI_EVT_CODE = 34,
+    HCI_RD_REM_EXT_FEATS_CMP_EVT_CODE = 35,
+    HCI_SYNC_CON_CMP_EVT_CODE = 44,
+    HCI_SYNC_CON_CHG_EVT_CODE = 45,
+    HCI_SNIFF_SUB_EVT_CODE = 46,
+    HCI_EXT_INQ_RES_EVT_CODE = 47,
+    HCI_ENC_KEY_REFRESH_CMP_EVT_CODE = 48,
+    HCI_IO_CAP_REQ_EVT_CODE = 49,
+    HCI_IO_CAP_RSP_EVT_CODE = 50,
+    HCI_USER_CFM_REQ_EVT_CODE = 51,
+    HCI_USER_PASSKEY_REQ_EVT_CODE = 52,
+    HCI_REM_OOB_DATA_REQ_EVT_CODE = 53,
+    HCI_SP_CMP_EVT_CODE = 54,
+    HCI_LINK_SUPV_TO_CHG_EVT_CODE = 56,
+    HCI_ENH_FLUSH_CMP_EVT_CODE = 57,
+    HCI_USER_PASSKEY_NOTIF_EVT_CODE = 59,
+    HCI_KEYPRESS_NOTIF_EVT_CODE = 60,
+    HCI_REM_HOST_SUPP_FEATS_NOTIF_EVT_CODE = 61,
+    HCI_LE_META_EVT_CODE = 62,
+    HCI_MAX_EVT_MSK_PAGE_1_CODE = 64,
+    HCI_SYNC_TRAIN_CMP_EVT_CODE = 79,
+    HCI_SYNC_TRAIN_REC_EVT_CODE = 80,
+    HCI_CON_SLV_BCST_REC_EVT_CODE = 81,
+    HCI_CON_SLV_BCST_TO_EVT_CODE = 82,
+    HCI_TRUNC_PAGE_CMP_EVT_CODE = 83,
+    HCI_SLV_PAGE_RSP_TO_EVT_CODE = 84,
+    HCI_CON_SLV_BCST_CH_MAP_CHG_EVT_CODE = 85,
+    HCI_AUTH_PAYL_TO_EXP_EVT_CODE = 87,
+    HCI_MAX_EVT_MSK_PAGE_2_CODE = 88,
+    HCI_DBG_META_EVT_CODE = 255,
+    HCI_LE_CON_CMP_EVT_SUBCODE = 1,
+    HCI_LE_ADV_REPORT_EVT_SUBCODE = 2,
+    HCI_LE_CON_UPDATE_CMP_EVT_SUBCODE = 3,
+    HCI_LE_RD_REM_USED_FEATS_CMP_EVT_SUBCODE = 4,
+    HCI_LE_LTK_REQUEST_EVT_SUBCODE = 5,
+    HCI_LE_REM_CON_PARAM_REQ_EVT_SUBCODE = 6,
+    HCI_LE_DATA_LEN_CHG_EVT_SUBCODE = 7,
+    HCI_LE_RD_LOC_P256_PUB_KEY_CMP_EVT_SUBCODE = 8,
+    HCI_LE_GEN_DHKEY_CMP_EVT_SUBCODE = 9,
+    HCI_LE_ENH_CON_CMP_EVT_SUBCODE = 10,
+    HCI_LE_DIR_ADV_REP_EVT_SUBCODE = 11,
+    HCI_LE_CH_SEL_ALGO_EVT_SUBCODE = 20,
+}; // :540:6
+
+enum hci_evt_mask_page {
+    HCI_PAGE_0 = 0,
+    HCI_PAGE_1 = 1,
+    HCI_PAGE_2 = 2,
+    HCI_PAGE_DFT = 3,
+}; // :642:6
+
+struct hci_acl_data_rx {
+    uint16_t conhdl;
+    uint8_t pb_bc_flag;
+    uint16_t length;
+    uint8_t rx_hdl;
+}; // :654:8
+
+struct hci_acl_data_tx {
+    uint16_t conhdl;
+    uint8_t pb_bc_flag;
+    uint16_t length;
+    struct em_buf_node *buf;
+}; // :673:8
+
+struct hci_basic_conhdl_cmd {
+    uint16_t conhdl;
+}; // :735:8
+
+struct hci_disconnect_cmd {
+    uint16_t conhdl;
+    uint8_t reason;
+}; // :1120:8
+
+struct hci_le_generate_dh_key_cmd {
+    uint8_t public_key[64];
+}; // :1396:8
+
+struct hci_set_evt_mask_cmd {
+    struct evt_mask event_mask;
+}; // :1445:8
+
+struct hci_flush_cmd_cmp_evt {
+    uint8_t status;
+    uint16_t conhdl;
+}; // :1535:8
+
+struct hci_set_ctrl_to_host_flow_ctrl_cmd {
+    uint8_t flow_cntl;
+}; // :1788:8
+
+struct hci_host_buf_size_cmd {
+    uint16_t acl_pkt_len;
+    uint8_t sync_pkt_len;
+    uint16_t nb_acl_pkts;
+    uint16_t nb_sync_pkts;
+}; // :1795:8
+
+struct hci_host_nb_cmp_pkts_cmd {
+    uint8_t nb_of_hdl;
+    uint16_t con_hdl[3];
+    uint16_t nb_comp_pkt[3];
+}; // :1820:8
+
+struct hci_rd_auth_payl_to_cmd {
+    uint16_t conhdl;
+}; // :2334:8
+
+struct hci_rd_auth_payl_to_cmd_cmp_evt {
+    uint8_t status;
+    uint16_t conhdl;
+    uint16_t auth_payl_to;
+}; // :2341:8
+
+struct hci_rd_local_ver_info_cmd_cmp_evt {
+    uint8_t status;
+    uint8_t hci_ver;
+    uint16_t hci_rev;
+    uint8_t lmp_ver;
+    uint16_t manuf_name;
+    uint16_t lmp_subver;
+}; // :2412:8
+
+struct hci_rd_local_supp_cmds_cmd_cmp_evt {
+    uint8_t status;
+    struct supp_cmds local_cmds;
+}; // :2429:8
+
+struct hci_rd_local_supp_feats_cmd_cmp_evt {
+    uint8_t status;
+    struct features feats;
+}; // :2438:8
+
+struct hci_rd_buff_size_cmd_cmp_evt {
+    uint8_t status;
+    uint16_t hc_data_pk_len;
+    uint8_t hc_sync_pk_len;
+    uint16_t hc_tot_nb_data_pkts;
+    uint16_t hc_tot_nb_sync_pkts;
+}; // :2466:8
+
+struct hci_rd_bd_addr_cmd_cmp_evt {
+    uint8_t status;
+    struct bd_addr local_addr;
+}; // :2481:8
+
+struct hci_rd_rssi_cmd_cmp_evt {
+    uint8_t status;
+    uint16_t conhdl;
+    int8_t rssi;
+}; // :2507:8
+
+struct hci_le_set_evt_mask_cmd {
+    struct evt_mask le_mask;
+}; // :2604:8
+
+struct hci_le_set_rand_addr_cmd {
+    struct bd_addr rand_addr;
+}; // :2611:8
+
+struct hci_le_set_adv_param_cmd {
+    uint16_t adv_intv_min;
+    uint16_t adv_intv_max;
+    uint8_t adv_type;
+    uint8_t own_addr_type;
+    uint8_t peer_addr_type;
+    struct bd_addr peer_addr;
+    uint8_t adv_chnl_map;
+    uint8_t adv_filt_policy;
+}; // :2754:8
+
+struct hci_le_set_adv_data_cmd {
+    uint8_t adv_data_len;
+    struct adv_data data;
+}; // :2775:8
+
+struct hci_le_set_scan_rsp_data_cmd {
+    uint8_t scan_rsp_data_len;
+    struct scan_rsp_data data;
+}; // :2784:8
+
+struct hci_le_set_adv_en_cmd {
+    uint8_t adv_en;
+}; // :2793:8
+
+struct hci_le_set_scan_param_cmd {
+    uint8_t scan_type;
+    uint16_t scan_intv;
+    uint16_t scan_window;
+    uint8_t own_addr_type;
+    uint8_t scan_filt_policy;
+}; // :2852:8
+
+struct hci_le_set_scan_en_cmd {
+    uint8_t scan_en;
+    uint8_t filter_duplic_en;
+}; // :2867:8
+
+struct hci_le_create_con_cmd {
+    uint16_t scan_intv;
+    uint16_t scan_window;
+    uint8_t init_filt_policy;
+    uint8_t peer_addr_type;
+    struct bd_addr peer_addr;
+    uint8_t own_addr_type;
+    uint16_t con_intv_min;
+    uint16_t con_intv_max;
+    uint16_t con_latency;
+    uint16_t superv_to;
+    uint16_t ce_len_min;
+    uint16_t ce_len_max;
+}; // :2876:8
+
+struct hci_le_wr_rfpath_cps_cmd {
+    uint16_t rf_txpath_compensation_value;
+    uint16_t rf_rxpath_compensation_value;
+}; // :2974:8
+
+struct hci_le_add_dev_to_wlst_cmd {
+    uint8_t dev_addr_type;
+    struct bd_addr dev_addr;
+}; // :2983:8
+
+struct hci_le_set_host_ch_class_cmd {
+    struct le_chnl_map chmap;
+}; // :3002:8
+
+struct hci_le_rx_test_cmd {
+    uint8_t rx_freq;
+}; // :3010:8
+
+struct hci_le_tx_test_cmd {
+    uint8_t tx_freq;
+    uint8_t test_data_len;
+    uint8_t pk_payload_type;
+}; // :3017:8
+
+struct hci_le_enc_cmd {
+    struct ltk key;
+    uint8_t plain_data[16];
+}; // :3054:8
+
+struct hci_le_con_update_cmd {
+    uint16_t conhdl;
+    uint16_t con_intv_min;
+    uint16_t con_intv_max;
+    uint16_t con_latency;
+    uint16_t superv_to;
+    uint16_t ce_len_min;
+    uint16_t ce_len_max;
+}; // :3063:8
+
+struct hci_le_start_enc_cmd {
+    uint16_t conhdl;
+    struct rand_nb nb;
+    uint16_t enc_div;
+    struct ltk ltk;
+}; // :3082:8
+
+struct hci_le_ltk_req_reply_cmd {
+    uint16_t conhdl;
+    struct ltk ltk;
+}; // :3095:8
+
+struct hci_le_rem_con_param_req_reply_cmd {
+    uint16_t conhdl;
+    uint16_t interval_min;
+    uint16_t interval_max;
+    uint16_t latency;
+    uint16_t timeout;
+    uint16_t min_ce_len;
+    uint16_t max_ce_len;
+}; // :3104:8
+
+struct hci_le_rem_con_param_req_neg_reply_cmd {
+    uint16_t conhdl;
+    uint8_t reason;
+}; // :3123:8
+
+struct hci_le_set_data_len_cmd {
+    uint16_t conhdl;
+    uint16_t tx_octets;
+    uint16_t tx_time;
+}; // :3133:8
+
+struct hci_le_wr_suggted_dft_data_len_cmd {
+    uint16_t suggted_max_tx_octets;
+    uint16_t suggted_max_tx_time;
+}; // :3146:8
+
+struct hci_vsc_set_tx_pwr_cmd {
+    int8_t power;
+}; // :3259:8
+
+struct hci_disc_cmp_evt {
+    uint8_t status;
+    uint16_t conhdl;
+    uint8_t reason;
+}; // :3341:8
+
+struct hci_basic_cmd_cmp_evt {
+    uint8_t status;
+}; // :3352:8
+
+struct hci_basic_conhdl_cmd_cmp_evt {
+    uint8_t status;
+    uint16_t conhdl;
+}; // :3359:8
+
+struct hci_cmd_stat_event {
+    uint8_t status;
+}; // :3393:8
+
+struct hci_nb_cmp_pkts_evt {
+    uint8_t nb_of_hdl;
+    uint16_t conhdl[1];
+    uint16_t nb_comp_pkt[1];
+}; // :3400:8
+
+struct hci_data_buf_ovflw_evt {
+    uint8_t link_type;
+}; // :3411:8
+
+struct hci_enc_change_evt {
+    uint8_t status;
+    uint16_t conhdl;
+    uint8_t enc_stat;
+}; // :3425:8
+
+struct hci_enc_key_ref_cmp_evt {
+    uint8_t status;
+    uint16_t conhdl;
+}; // :3436:8
+
+struct hci_auth_payl_to_exp_evt {
+    uint16_t conhdl;
+}; // :3445:8
+
+struct hci_flush_occurred_evt {
+    uint16_t conhdl;
+}; // :3533:8
+
+struct hci_rd_rem_ver_info_cmp_evt {
+    uint8_t status;
+    uint16_t conhdl;
+    uint8_t vers;
+    uint16_t compid;
+    uint16_t subvers;
+}; // :3601:8
+
+struct hci_le_rd_local_supp_feats_cmd_cmp_evt {
+    uint8_t status;
+    struct le_features feats;
+}; // :3881:8
+
+struct hci_rd_adv_chnl_tx_pw_cmd_cmp_evt {
+    uint8_t status;
+    int8_t adv_tx_pw_lvl;
+}; // :3890:8
+
+struct hci_rd_wlst_size_cmd_cmp_evt {
+    uint8_t status;
+    uint8_t wlst_size;
+}; // :3899:8
+
+struct hci_le_rd_buff_size_cmd_cmp_evt {
+    uint8_t status;
+    uint16_t hc_data_pk_len;
+    uint8_t hc_tot_nb_data_pkts;
+}; // :3908:8
+
+struct hci_le_rand_cmd_cmp_evt {
+    uint8_t status;
+    struct rand_nb nb;
+}; // :3927:8
+
+struct hci_rd_supp_states_cmd_cmp_evt {
+    uint8_t status;
+    struct le_states states;
+}; // :3936:8
+
+struct hci_rd_trans_pwr_cmd_cmp_evt {
+    uint8_t status;
+    char min_tx_pwr;
+    char max_tx_pwr;
+}; // :3962:8
+
+struct hci_rd_rfpath_cps_cmd_cmp_evt {
+    uint8_t status;
+    uint16_t rf_txpath_compensation_value;
+    uint16_t rf_rxpath_compensation_value;
+}; // :3972:8
+
+struct hci_test_end_cmd_cmp_evt {
+    uint8_t status;
+    uint16_t nb_packet_received;
+}; // :3984:8
+
+struct hci_le_enc_cmd_cmp_evt {
+    uint8_t status;
+    uint8_t encrypted_data[16];
+}; // :3993:8
+
+struct hci_le_adv_report_evt {
+    uint8_t subcode;
+    uint8_t nb_reports;
+    struct adv_report adv_rep[1];
+}; // :4003:8
+
+struct hci_le_rd_chnl_map_cmd_cmp_evt {
+    uint8_t status;
+    uint16_t conhdl;
+    struct le_chnl_map ch_map;
+}; // :4035:8
+
+struct hci_le_rd_suggted_dft_data_len_cmd_cmp_evt {
+    uint8_t status;
+    uint16_t suggted_max_tx_octets;
+    uint16_t suggted_max_tx_time;
+}; // :4064:8
+
+struct hci_le_rd_max_data_len_cmd_cmp_evt {
+    uint8_t status;
+    uint16_t suppted_max_tx_octets;
+    uint16_t suppted_max_tx_time;
+    uint16_t suppted_max_rx_octets;
+    uint16_t suppted_max_rx_time;
+}; // :4074:8
+
+struct hci_wr_auth_payl_to_cmd {
+    uint16_t conhdl;
+    uint16_t auth_payl_to;
+}; // :4117:8
+
+struct hci_wr_auth_payl_to_cmd_cmp_evt {
+    uint8_t status;
+    uint16_t conhdl;
+}; // :4126:8
+
+struct hci_le_con_update_cmp_evt {
+    uint8_t subcode;
+    uint8_t status;
+    uint16_t conhdl;
+    uint16_t con_interval;
+    uint16_t con_latency;
+    uint16_t sup_to;
+}; // :4135:8
+
+struct hci_le_con_cmp_evt {
+    uint8_t subcode;
+    uint8_t status;
+    uint16_t conhdl;
+    uint8_t role;
+    uint8_t peer_addr_type;
+    struct bd_addr peer_addr;
+    uint16_t con_interval;
+    uint16_t con_latency;
+    uint16_t sup_to;
+    uint8_t clk_accuracy;
+}; // :4152:8
+
+struct hci_le_rd_rem_used_feats_cmd {
+    uint16_t conhdl;
+}; // :4177:8
+
+struct hci_le_rd_rem_used_feats_cmd_cmp_evt {
+    uint8_t subcode;
+    uint8_t status;
+    uint16_t conhdl;
+    struct le_features feats_used;
+}; // :4184:8
+
+struct hci_rd_tx_pwr_lvl_cmd {
+    uint16_t conhdl;
+    uint8_t type;
+}; // :4197:8
+
+struct hci_rd_tx_pwr_lvl_cmd_cmp_evt {
+    uint8_t status;
+    uint16_t conhdl;
+    uint8_t tx_pow_lvl;
+}; // :4206:8
+
+struct hci_rd_rem_ver_info_cmd {
+    uint16_t conhdl;
+}; // :4217:8
+
+struct hci_le_rem_con_param_req_evt {
+    uint8_t subcode;
+    uint16_t conhdl;
+    uint16_t interval_min;
+    uint16_t interval_max;
+    uint16_t latency;
+    uint16_t timeout;
+}; // :4224:8
+
+struct hci_le_enh_con_cmp_evt {
+    uint8_t subcode;
+    uint8_t status;
+    uint16_t conhdl;
+    uint8_t role;
+    uint8_t peer_addr_type;
+    struct bd_addr peer_addr;
+    struct bd_addr loc_rslv_priv_addr;
+    struct bd_addr peer_rslv_priv_addr;
+    uint16_t con_interval;
+    uint16_t con_latency;
+    uint16_t sup_to;
+    uint8_t clk_accuracy;
+}; // :4242:8
+
+struct hci_le_dir_adv_rep_evt {
+    uint8_t subcode;
+    uint8_t nb_reports;
+    struct dir_adv_report adv_rep[1];
+}; // :4295:8
+
+struct hci_le_ltk_request_evt {
+    uint8_t subcode;
+    uint16_t conhdl;
+    struct rand_nb rand;
+    uint16_t ediv;
+}; // :4307:8
+
+struct hci_le_data_len_chg_evt {
+    uint8_t subcode;
+    uint16_t conhdl;
+    uint16_t max_tx_octets;
+    uint16_t max_tx_time;
+    uint16_t max_rx_octets;
+    uint16_t max_rx_time;
+}; // :4320:8
+
+struct hci_le_generate_dhkey_cmp_evt {
+    uint8_t subcode;
+    uint8_t status;
+    uint8_t dh_key[32];
+}; // :4412:8
+
+struct hci_le_generate_p256_public_key_cmp_evt {
+    uint8_t subcode;
+    uint8_t status;
+    t_public_key public_key;
+}; // :4420:8
+
+struct hci_le_ch_sel_algo_evt {
+    uint8_t subcode;
+    uint16_t conhdl;
+    uint8_t chSel;
+}; // :4445:8
+
+/* ======== components/network/ble/blecontroller/modules/common/api/co_list.h ======== */
+
+struct co_list_hdr {
+    struct co_list_hdr *next;
+}; // :53:8
+
+struct co_list {
+    struct co_list_hdr *first;
+    struct co_list_hdr *last;
+}; // :60:8
+
+/* ======== components/network/ble/blecontroller/modules/common/api/co_llcp.h ======== */
+
+enum co_llcp_opcode {
+    LLCP_CONNECTION_UPDATE_IND_OPCODE = 0,
+    LLCP_CHANNEL_MAP_IND_OPCODE = 1,
+    LLCP_TERMINATE_IND_OPCODE = 2,
+    LLCP_ENC_REQ_OPCODE = 3,
+    LLCP_ENC_RSP_OPCODE = 4,
+    LLCP_START_ENC_REQ_OPCODE = 5,
+    LLCP_START_ENC_RSP_OPCODE = 6,
+    LLCP_UNKNOWN_RSP_OPCODE = 7,
+    LLCP_FEATURE_REQ_OPCODE = 8,
+    LLCP_FEATURE_RSP_OPCODE = 9,
+    LLCP_PAUSE_ENC_REQ_OPCODE = 10,
+    LLCP_PAUSE_ENC_RSP_OPCODE = 11,
+    LLCP_VERSION_IND_OPCODE = 12,
+    LLCP_REJECT_IND_OPCODE = 13,
+    LLCP_SLAVE_FEATURE_REQ_OPCODE = 14,
+    LLCP_CONNECTION_PARAM_REQ_OPCODE = 15,
+    LLCP_CONNECTION_PARAM_RSP_OPCODE = 16,
+    LLCP_REJECT_IND_EXT_OPCODE = 17,
+    LLCP_PING_REQ_OPCODE = 18,
+    LLCP_PING_RSP_OPCODE = 19,
+    LLCP_LENGTH_REQ_OPCODE = 20,
+    LLCP_LENGTH_RSP_OPCODE = 21,
+    LLCP_OPCODE_MAX_OPCODE = 22,
+}; // :41:6
+
+enum co_llcp_length {
+    LLCP_CON_REQ_LEN = 34,
+    LLCP_CON_UPD_IND_LEN = 12,
+    LLCP_CH_MAP_REQ_LEN = 8,
+    LLCP_TERM_IND_LEN = 2,
+    LLCP_ENC_REQ_LEN = 23,
+    LLCP_ENC_RSP_LEN = 13,
+    LLCP_ST_ENC_REQ_LEN = 1,
+    LLCP_ST_ENC_RSP_LEN = 1,
+    LLCP_UNKN_RSP_LEN = 2,
+    LLCP_FEAT_REQ_LEN = 9,
+    LLCP_FEAT_RSP_LEN = 9,
+    LLCP_PA_ENC_REQ_LEN = 1,
+    LLCP_PA_ENC_RSP_LEN = 1,
+    LLCP_VERS_IND_LEN = 6,
+    LLCP_REJ_IND_LEN = 2,
+    LLCP_SLAVE_FEATURE_REQ_LEN = 9,
+    LLCP_REJECT_IND_EXT_LEN = 3,
+    LLCP_CON_PARAM_REQ_LEN = 24,
+    LLCP_CON_PARAM_RSP_LEN = 24,
+    LLCP_PING_REQ_LEN = 1,
+    LLCP_PING_RSP_LEN = 1,
+    LLCP_LENGTH_REQ_LEN = 9,
+    LLCP_LENGTH_RSP_LEN = 9,
+    LLCP_PDU_LENGTH_MAX = 34,
+}; // :106:6
+
+struct llcp_con_upd_ind {
+    uint8_t opcode;
+    uint8_t win_size;
+    uint16_t win_off;
+    uint16_t interv;
+    uint16_t latency;
+    uint16_t timeout;
+    uint16_t instant;
+}; // :146:8
+
+struct llcp_channel_map_ind {
+    uint8_t opcode;
+    struct le_chnl_map ch_map;
+    uint16_t instant;
+}; // :165:8
+
+struct llcp_terminate_ind {
+    uint8_t opcode;
+    uint8_t err_code;
+}; // :176:8
+
+struct llcp_enc_req {
+    uint8_t opcode;
+    struct rand_nb rand;
+    uint8_t ediv[2];
+    struct sess_k_div_x skdm;
+    struct init_vect ivm;
+}; // :185:8
+
+struct llcp_enc_rsp {
+    uint8_t opcode;
+    struct sess_k_div_x skds;
+    struct init_vect ivs;
+}; // :200:8
+
+struct llcp_start_enc_req {
+    uint8_t opcode;
+}; // :211:8
+
+struct llcp_start_enc_rsp {
+    uint8_t opcode;
+}; // :218:8
+
+struct llcp_unknown_rsp {
+    uint8_t opcode;
+    uint8_t unk_type;
+}; // :225:8
+
+struct llcp_feats_req {
+    uint8_t opcode;
+    struct le_features feats;
+}; // :234:8
+
+struct llcp_feats_rsp {
+    uint8_t opcode;
+    struct le_features feats;
+}; // :243:8
+
+struct llcp_pause_enc_req {
+    uint8_t opcode;
+}; // :252:8
+
+struct llcp_pause_enc_rsp {
+    uint8_t opcode;
+}; // :259:8
+
+struct llcp_vers_ind {
+    uint8_t opcode;
+    uint8_t vers;
+    uint16_t compid;
+    uint16_t subvers;
+}; // :266:8
+
+struct llcp_reject_ind {
+    uint8_t opcode;
+    uint8_t err_code;
+}; // :279:8
+
+struct llcp_slave_feature_req {
+    uint8_t opcode;
+    struct le_features feats;
+}; // :288:8
+
+struct llcp_con_param_req {
+    uint8_t opcode;
+    uint16_t interval_min;
+    uint16_t interval_max;
+    uint16_t latency;
+    uint16_t timeout;
+    uint8_t pref_period;
+    uint16_t ref_con_event_count;
+    uint16_t offset0;
+    uint16_t offset1;
+    uint16_t offset2;
+    uint16_t offset3;
+    uint16_t offset4;
+    uint16_t offset5;
+}; // :297:8
+
+struct llcp_con_param_rsp {
+    uint8_t opcode;
+    uint16_t interval_min;
+    uint16_t interval_max;
+    uint16_t latency;
+    uint16_t timeout;
+    uint8_t pref_period;
+    uint16_t ref_con_event_count;
+    uint16_t offset0;
+    uint16_t offset1;
+    uint16_t offset2;
+    uint16_t offset3;
+    uint16_t offset4;
+    uint16_t offset5;
+}; // :328:8
+
+struct llcp_reject_ind_ext {
+    uint8_t opcode;
+    uint8_t rej_opcode;
+    uint8_t err_code;
+}; // :359:8
+
+struct llcp_ping_req {
+    uint8_t opcode;
+}; // :370:8
+
+struct llcp_ping_rsp {
+    uint8_t opcode;
+}; // :377:8
+
+struct llcp_length_req {
+    uint8_t opcode;
+    uint16_t max_rx_octets;
+    uint16_t max_rx_time;
+    uint16_t max_tx_octets;
+    uint16_t max_tx_time;
+}; // :384:8
+
+struct llcp_length_rsp {
+    uint8_t opcode;
+    uint16_t max_rx_octets;
+    uint16_t max_rx_time;
+    uint16_t max_tx_octets;
+    uint16_t max_tx_time;
+}; // :399:8
+
+union llcp_pdu {
+    uint8_t opcode;
+    struct llcp_con_upd_ind con_up_req;
+    struct llcp_channel_map_ind channel_map_req;
+    struct llcp_terminate_ind terminate_ind;
+    struct llcp_enc_req enc_req;
+    struct llcp_enc_rsp enc_rsp;
+    struct llcp_start_enc_req start_enc_req;
+    struct llcp_start_enc_rsp start_enc_rsp;
+    struct llcp_unknown_rsp unknown_rsp;
+    struct llcp_feats_req feats_req;
+    struct llcp_feats_rsp feats_rsp;
+    struct llcp_pause_enc_req pause_enc_req;
+    struct llcp_pause_enc_rsp pause_enc_rsp;
+    struct llcp_vers_ind vers_ind;
+    struct llcp_reject_ind reject_ind;
+    struct llcp_slave_feature_req slave_feature_req;
+    struct llcp_con_param_req con_param_req;
+    struct llcp_con_param_rsp con_param_rsp;
+    struct llcp_reject_ind_ext reject_ind_ext;
+    struct llcp_ping_req ping_req;
+    struct llcp_ping_rsp ping_rsp;
+    struct llcp_length_req length_req;
+    struct llcp_length_rsp length_rsp;
+}; // :451:7
+
+/* ======== components/network/ble/blecontroller/modules/common/api/co_string.h ======== */
+
+void *(*ble_memcpy_ptr)(void *, const void *, unsigned int); // :7:16
+void *(*ble_memset_ptr)(void *, int, unsigned int); // :8:16
+int (*ble_memcmp_ptr)(const void *, const void *, unsigned int); // :9:14
+
+/* ======== components/network/ble/blecontroller/modules/common/api/co_utils.h ======== */
+
+const unsigned char one_bits[16]; // :119:28
+const uint16_t co_sca2ppm[]; // :122:23
+const struct bd_addr co_null_bdaddr; // :125:29
+struct bd_addr co_default_bdaddr; // :128:23
+
+/* ======== components/network/ble/blecontroller/modules/common/src/co_list.c ======== */
+
+uint32_t _patch_ble_co_list_init(void *pRet, struct co_list *list); // :35:10
+void ble_co_list_init(struct co_list *list); // :50:7
+void ble_co_list_pool_init(struct co_list *list, void *pool, size_t elmt_size, uint32_t elmt_cnt, void *default_value, uint8_t list_type); // :68:6
+uint32_t _patch_ble_co_list_push_back(void *pRet, struct co_list *list, struct co_list_hdr *list_hdr); // :127:10
+void ble_co_list_push_back(struct co_list *list, struct co_list_hdr *list_hdr); // :161:7
+uint32_t _patch_ble_co_list_push_front(void *pRet, struct co_list *list, struct co_list_hdr *list_hdr); // :198:10
+void ble_co_list_push_front(struct co_list *list, struct co_list_hdr *list_hdr); // :227:7
+uint32_t _patch_ble_co_list_pop_front(void *pRet, struct co_list *list); // :259:10
+struct co_list_hdr *ble_co_list_pop_front(struct co_list *list); // :289:22
+uint32_t _patch_ble_co_list_extract(void *pRet, struct co_list *list, struct co_list_hdr *list_hdr, uint8_t nb_following); // :323:10
+bool ble_co_list_extract(struct co_list *list, struct co_list_hdr *list_hdr, uint8_t nb_following); // :399:24
+uint32_t _patch_ble_co_list_extract_after(void *pRet, struct co_list *list, struct co_list_hdr *elt_ref_hdr, struct co_list_hdr *elt_to_rem_hdr); // :480:10
+void ble_co_list_extract_after(struct co_list *list, struct co_list_hdr *elt_ref_hdr, struct co_list_hdr *elt_to_rem_hdr); // :522:7
+uint32_t _patch_ble_co_list_find(void *pRet, struct co_list *list, struct co_list_hdr *list_hdr); // :567:10
+bool ble_co_list_find(struct co_list *list, struct co_list_hdr *list_hdr); // :588:24
+uint32_t _patch_ble_co_list_merge(void *pRet, struct co_list *list1, struct co_list *list2); // :611:10
+void ble_co_list_merge(struct co_list *list1, struct co_list *list2); // :644:7
+uint32_t _patch_ble_co_list_insert_before(void *pRet, struct co_list *list, struct co_list_hdr *elt_ref_hdr, struct co_list_hdr *elt_to_add_hdr); // :680:10
+void ble_co_list_insert_before(struct co_list *list, struct co_list_hdr *elt_ref_hdr, struct co_list_hdr *elt_to_add_hdr); // :728:7
+uint32_t _patch_ble_co_list_insert_after(void *pRet, struct co_list *list, struct co_list_hdr *elt_ref_hdr, struct co_list_hdr *elt_to_add_hdr); // :779:10
+void ble_co_list_insert_after(struct co_list *list, struct co_list_hdr *elt_ref_hdr, struct co_list_hdr *elt_to_add_hdr); // :832:7
+uint32_t _patch_ble_co_list_size(void *pRet, struct co_list *list); // :888:10
+uint16_t ble_co_list_size(struct co_list *list); // :905:11
+uint32_t _patch_ble_co_list_check_size_available(void *pRet, struct co_list *list, uint8_t free_size_needed); // :927:10
+bool ble_co_list_check_size_available(struct co_list *list, uint8_t free_size_needed); // :948:24
+
+/* ======== components/network/ble/blecontroller/modules/common/src/co_utils.c ======== */
+
+const unsigned char one_bits[16]; // :53:21
+const uint16_t co_sca2ppm[]; // :56:16
+const struct bd_addr co_null_bdaddr; // :69:22
+struct bd_addr co_default_bdaddr; // :72:16
+
+void co_bdaddr_set(uint8_t *bdaddr); // :106:6
+bool co_bdaddr_compare(const struct bd_addr *bd_address1, const struct bd_addr *bd_address2); // :111:5
+
+/* ======== components/network/ble/blecontroller/modules/dbg/src/dbg.c ======== */
+
+void ble_dbg_platform_reset_complete(uint32_t error); // :81:6
+
+/* ======== components/network/ble/blecontroller/modules/ecc_p256/api/ecc_p256.h ======== */
+
+struct ecc_result_ind {
+    uint8_t key_res_x[32];
+    uint8_t key_res_y[32];
+}; // :47:8
+
+/* ======== components/network/ble/blecontroller/modules/ecc_p256/src/ecc_p256.c ======== */
+
+typedef long long unsigned int u64; // :110:32
+typedef uint8_t u_int8; // :112:17
+typedef uint32_t u_int32; // :114:18
+
+struct bigHex256 {
+    u_int32 num[8];
+    u_int32 len;
+    u_int32 sign;
+}; // :143:16
+
+typedef struct bigHex256 bigHex256; // :148:3
+
+struct ECC_Point256 {
+    bigHex256 x;
+    bigHex256 y;
+}; // :159:16
+
+typedef struct ECC_Point256 ECC_Point256; // :163:3
+
+struct ECC_Jacobian_Point256 {
+    bigHex256 x;
+    bigHex256 y;
+    bigHex256 z;
+}; // :165:16
+
+typedef struct ECC_Jacobian_Point256 ECC_Jacobian_Point256; // :170:3
+
+struct ecc_elt_tag {
+    struct co_list_hdr hdr;
+    u_int32 Point_Mul_Word256;
+    ECC_Jacobian_Point256 Jacobian_PointQ256;
+    ECC_Jacobian_Point256 Jacobian_PointR256;
+    bigHex256 Pk256;
+    ke_msg_id_t msg_id;
+    ke_task_id_t client_id;
+    uint32_t current_val;
+    uint32_t bit_cursor;
+    uint8_t key_type;
+    ECC_Jacobian_Point256 *win_4_table;
+}; // :175:8
+
+struct ecc_env_tag {
+    struct co_list ongoing_mul;
+}; // :209:8
+
+const u_int8 BasePoint_x_256[32]; // :227:14
+const u_int8 BasePoint_y_256[32]; // :228:14
+const u_int8 maxSecretKey_256[32]; // :230:14
+const u_int8 DebugE256PublicKey_x[32]; // :232:14
+const u_int8 DebugE256PublicKey_y[32]; // :233:14
+const u_int8 DebugE256SecretKey[32]; // :235:14
+const bigHex256 bigHexP256; // :257:17
+const uint32_t Inv_r[8]; // :259:16
+const uint32_t Nprime[8]; // :261:16
+const uint32_t Bar_1[8]; // :263:16
+const uint32_t Bar_2[8]; // :264:16
+const uint32_t Bar_3[8]; // :265:16
+const uint32_t Bar_4[8]; // :266:16
+const uint32_t Bar_8[8]; // :267:16
+const uint32_t Bar_1p1[8]; // :268:16
+const uint32_t Bar_1m1[8]; // :269:16
+const ECC_Jacobian_Point256 ECC_4Win_Look_up_table[15]; // :402:29
+struct ecc_env_tag ecc_env; // :626:20
+
+static void Mont2GF(uint8_t reg_idx); // :722:13
+static void getFinalPoint(uint8_t reg_idx); // :733:13
+int notEqual256(const bigHex256 *bigHexA, const bigHex256 *bigHexB); // :1963:20
+void GF_Point_Jacobian_To_Affine256(ECC_Jacobian_Point256 *pJacPoint, bigHex256 *pX_co_ord_affine, bigHex256 *pY_co_ord_affine); // :2359:6
+void bigHexInversion256(bigHex256 *bigHexA, bigHex256 *pResult); // :2448:6
+static void ecc_multiplication_event_handler(void); // :2862:13
+void ecc_init(bool reset); // :2999:6
+bool ecc_is_valid_point(bigHex256 *X_coord, bigHex256 *Y_coord); // :3019:5
+uint8_t ecc_generate_key256(u_int8 key_type, const u_int8 *secret_key, const u_int8 *public_key_x, const u_int8 *public_key_y, ke_msg_id_t msg_id, ke_task_id_t task_id); // :3074:9
+void ecc_abort_key256_generation(ke_task_id_t task_id); // :3230:6
+void ecc_gen_new_public_key(u_int8 *secret_key, ke_msg_id_t msg_id, ke_task_id_t task_id); // :3270:6
+void ecc_gen_new_secret_key(uint8_t *secret_key256, bool forced); // :3280:6
+void ecc_get_debug_Keys(uint8_t *secret_key, uint8_t *pub_key_x, uint8_t *pub_key_y); // :3311:6
+
+/* ======== components/network/ble/blecontroller/modules/ke/api/ke_event.h ======== */
+
+enum KE_EVENT_STATUS {
+    KE_EVENT_OK = 0,
+    KE_EVENT_FAIL = 1,
+    KE_EVENT_UNKNOWN = 2,
+    KE_EVENT_CAPA_EXCEEDED = 3,
+    KE_EVENT_ALREADY_EXISTS = 4,
+}; // :47:6
+
+/* ======== components/network/ble/blecontroller/modules/ke/api/ke_msg.h ======== */
+
+typedef uint16_t ke_task_id_t; // :58:18
+typedef uint8_t ke_state_t; // :70:17
+typedef uint16_t ke_msg_id_t; // :76:18
+
+struct ke_msg {
+    struct co_list_hdr hdr;
+    ke_msg_id_t id;
+    ke_task_id_t dest_id;
+    ke_task_id_t src_id;
+    uint16_t param_len;
+    uint32_t param[1];
+}; // :79:8
+
+enum ke_msg_status_tag {
+    KE_MSG_CONSUMED = 0,
+    KE_MSG_NO_FREE = 1,
+    KE_MSG_SAVED = 2,
+}; // :92:6
+
+/* ======== components/network/ble/blecontroller/modules/ke/api/ke_task.h ======== */
+
+enum KE_TASK_STATUS {
+    KE_TASK_OK = 0,
+    KE_TASK_FAIL = 1,
+    KE_TASK_UNKNOWN = 2,
+    KE_TASK_CAPA_EXCEEDED = 3,
+    KE_TASK_ALREADY_EXISTS = 4,
+}; // :48:6
+
+typedef int (*ke_msg_func_t)(const ke_msg_id_t, const void *, const ke_task_id_t, const ke_task_id_t); // :62:15
+
+struct ke_msg_handler {
+    ke_msg_id_t id;
+    ke_msg_func_t func;
+}; // :78:8
+
+struct ke_state_handler {
+    const struct ke_msg_handler *msg_table;
+    uint16_t msg_cnt;
+}; // :87:8
+
+struct ke_task_desc {
+    const struct ke_state_handler *state_handler;
+    const struct ke_state_handler *default_handler;
+    ke_state_t *state;
+    uint16_t state_max;
+    uint16_t idx_max;
+}; // :102:8
+
+/* ======== components/network/ble/blecontroller/modules/ke/api/ke_timer.h ======== */
+
+struct ke_timer {
+    struct ke_timer *next;
+    ke_msg_id_t id;
+    ke_task_id_t task;
+    uint32_t time;
+}; // :47:8
+
+/* ======== components/network/ble/blecontroller/modules/ke/src/ke.c ======== */
+
+struct ble_ke_env_tag ble_ke_env; // :47:24
+
+uint32_t _patch_ble_ke_init(void *pRet); // :57:10
+void ble_ke_init(void); // :90:7
+uint32_t _patch_ble_ke_flush(void *pRet); // :126:10
+void ble_ke_flush(void); // :160:7
+uint32_t _patch_ble_ke_sleep_check(void *pRet); // :197:10
+bool ble_ke_sleep_check(void); // :207:24
+
+/* ======== components/network/ble/blecontroller/modules/ke/src/ke_env.h ======== */
+
+struct ble_ke_env_tag {
+    struct co_list queue_sent;
+    struct co_list queue_saved;
+    struct co_list queue_timer;
+    struct mblock_free *heap[2];
+    uint16_t heap_size[2];
+}; // :40:8
+
+struct ble_ke_env_tag ble_ke_env; // :67:30
+
+/* ======== components/network/ble/blecontroller/modules/ke/src/ke_event.c ======== */
+
+typedef void (*p_callback_t)(void); // :48:16
+
+struct ble_ke_event_env_tag {
+    uint32_t event_field;
+    p_callback_t callback[10];
+    uint8_t state;
+}; // :61:8
+
+struct ble_ke_event_env_tag ble_ke_event_env; // :80:30
+
+uint32_t _patch_ble_ke_event_init(void *pRet); // :97:10
+void ble_ke_event_init(void); // :104:7
+uint32_t _patch_ble_ke_event_callback_set(void *pRet, uint8_t event_type, void (*p_callback)(void)); // :115:10
+uint8_t ble_ke_event_callback_set(uint8_t event_type, void (*p_callback)(void)); // :134:10
+uint32_t _patch_ble_ke_event_set(void *pRet, uint8_t event_type); // :160:10
+void ble_ke_event_set(uint8_t event_type); // :184:7
+uint32_t _patch_ble_ke_event_clear(void *pRet, uint8_t event_type); // :211:10
+void ble_ke_event_clear(uint8_t event_type); // :229:7
+uint8_t ble_ke_event_get(uint8_t event_type); // :250:9
+uint32_t _patch_ble_ke_event_get_all(void *pRet); // :269:10
+uint32_t ble_ke_event_get_all(void); // :276:11
+uint32_t _patch_ble_ke_event_flush(void *pRet); // :288:10
+void ble_ke_event_flush(void); // :295:7
+uint32_t _patch_ble_ke_event_schedule(void *pRet); // :306:10
+void ble_ke_event_schedule(void); // :342:7
+
+/* ======== components/network/ble/blecontroller/modules/ke/src/ke_mem.c ======== */
+
+struct mblock_free {
+    uint16_t corrupt_check;
+    uint16_t free_size;
+    struct mblock_free *next;
+    struct mblock_free *previous;
+}; // :49:8
+
+struct mblock_used {
+    uint16_t corrupt_check;
+    uint16_t size;
+}; // :62:8
+
+uint32_t _patch_ble_ke_mem_is_in_heap(void *pRet, uint8_t type, void *mem_ptr); // :76:10
+bool ble_ke_mem_is_in_heap(uint8_t type, void *mem_ptr); // :95:24
+uint32_t _patch_ble_ke_mem_init(void *pRet, uint8_t type, uint8_t *heap, uint16_t heap_size); // :125:10
+void ble_ke_mem_init(uint8_t type, uint8_t *heap, uint16_t heap_size); // :157:7
+bool ble_ke_mem_is_empty(uint8_t type); // :192:5
+bool ble_ke_check_malloc(uint32_t size, uint8_t type); // :227:5
+uint32_t _patch_ble_ke_malloc(void *pRet, uint32_t size, uint8_t type); // :297:10
+void *ble_ke_malloc(uint32_t size, uint8_t type); // :455:8
+uint32_t _patch_ble_ke_free(void *pRet, void *mem_ptr); // :618:10
+void ble_ke_free(void *mem_ptr); // :752:7
+uint32_t _patch_ble_ke_is_free(void *pRet, void *mem_ptr); // :889:10
+bool ble_ke_is_free(void *mem_ptr); // :898:24
+
+/* ======== components/network/ble/blecontroller/modules/ke/src/ke_msg.c ======== */
+
+uint32_t _patch_ble_ke_msg_alloc(void *pRet, const ke_msg_id_t id, const ke_task_id_t dest_id, const ke_task_id_t src_id, const uint16_t param_len); // :49:10
+void *ble_ke_msg_alloc(const ke_msg_id_t id, const ke_task_id_t dest_id, const ke_task_id_t src_id, const uint16_t param_len); // :71:8
+uint32_t _patch_ble_ke_msg_send(void *pRet, const void *param_ptr); // :99:10
+void ble_ke_msg_send(const void *param_ptr); // :114:7
+uint32_t _patch_ble_ke_msg_get_sent_num(void *pRet); // :132:10
+uint16_t ble_ke_msg_get_sent_num(void); // :144:11
+uint32_t _patch_ble_ke_msg_send_basic(void *pRet, const ke_msg_id_t id, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :161:10
+void ble_ke_msg_send_basic(const ke_msg_id_t id, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :170:7
+void ble_ke_msg_forward(const void *param_ptr, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :182:6
+void ble_ke_msg_forward_new_id(const void *param_ptr, const ke_msg_id_t msg_id, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :194:6
+uint32_t _patch_ble_ke_msg_free(void *pRet, const struct ke_msg *msg); // :209:10
+void ble_ke_msg_free(const struct ke_msg *msg); // :216:7
+ke_msg_id_t ble_ke_msg_dest_id_get(const void *param_ptr); // :227:13
+ke_msg_id_t ble_ke_msg_src_id_get(const void *param_ptr); // :235:13
+bool ble_ke_msg_in_queue(const void *param_ptr); // :243:5
+
+/* ======== components/network/ble/blecontroller/modules/ke/src/ke_queue.c ======== */
+
+uint32_t _patch_ble_ke_queue_extract(void *pRet, struct co_list *const queue, bool (*func)(const struct co_list_hdr *, uint32_t), uint32_t arg); // :38:10
+struct co_list_hdr *ble_ke_queue_extract(struct co_list *const queue, bool (*func)(const struct co_list_hdr *, uint32_t), uint32_t arg); // :94:22
+uint32_t _patch_ble_ke_queue_insert(void *pRet, struct co_list *const queue, struct co_list_hdr *const element, bool (*cmp)(const struct co_list_hdr *, const struct co_list_hdr *)); // :155:10
+void ble_ke_queue_insert(struct co_list *const queue, struct co_list_hdr *const element, bool (*cmp)(const struct co_list_hdr *, const struct co_list_hdr *)); // :207:7
+
+/* ======== components/network/ble/blecontroller/modules/ke/src/ke_task.c ======== */
+
+struct ke_task_elem {
+    const struct ke_task_desc *p_desc;
+}; // :54:8
+
+struct ble_ke_task_env_tag {
+    struct ke_task_elem task_list[5];
+}; // :60:8
+
+struct ble_ke_task_env_tag ble_ke_task_env; // :73:29
+
+uint32_t _patch_ble_cmp_dest_id(void *pRet, const struct co_list_hdr *msg, uint32_t dest_id); // :94:10
+bool ble_cmp_dest_id(const struct co_list_hdr *msg, uint32_t dest_id); // :104:24
+uint32_t _patch_ble_ke_task_saved_update(void *pRet, const ke_task_id_t ke_task_id); // :129:10
+void ble_ke_task_saved_update(const ke_task_id_t ke_task_id); // :155:7
+uint32_t _patch_ble_ke_handler_search(void *pRet, const ke_msg_id_t msg_id, const struct ke_state_handler *state_handler); // :200:10
+ke_msg_func_t ble_ke_handler_search(const ke_msg_id_t msg_id, const struct ke_state_handler *state_handler); // :224:16
+uint32_t _patch_ble_ke_task_handler_get(void *pRet, const ke_msg_id_t msg_id, const ke_task_id_t task_id); // :263:10
+ke_msg_func_t ble_ke_task_handler_get(const ke_msg_id_t msg_id, const ke_task_id_t task_id); // :301:16
+uint32_t _patch_ble_ke_task_schedule(void *pRet); // :357:10
+void ble_ke_task_schedule(void); // :431:7
+uint32_t _patch_ble_ke_task_init(void *pRet); // :514:10
+void ble_ke_task_init(void); // :525:7
+uint32_t _patch_ble_ke_task_create(void *pRet, uint8_t task_type, const struct ke_task_desc *p_task_desc); // :539:10
+uint8_t ble_ke_task_create(uint8_t task_type, const struct ke_task_desc *p_task_desc); // :571:10
+uint8_t ble_ke_task_delete(uint8_t task_type); // :608:9
+uint32_t _patch_ble_ke_state_set(void *pRet, const ke_task_id_t id, const ke_state_t state_id); // :630:10
+void ble_ke_state_set(const ke_task_id_t id, const ke_state_t state_id); // :670:7
+uint32_t _patch_ble_ke_state_get(void *pRet, const ke_task_id_t id); // :713:10
+ke_state_t ble_ke_state_get(const ke_task_id_t id); // :743:13
+int ble_ke_msg_discard(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :779:5
+int ble_ke_msg_save(const ke_msg_id_t msgid, const void *param, const ke_task_id_t dest_id, const ke_task_id_t src_id); // :785:5
+void ble_ke_task_msg_flush(ke_task_id_t task); // :793:6
+ke_task_id_t ble_ke_task_check(ke_task_id_t task); // :833:14
+
+/* ======== components/network/ble/blecontroller/modules/ke/src/ke_timer.c ======== */
+
+uint32_t _patch_ke_time(void *pRet); // :86:10
+uint32_t ble_ke_time(void); // :121:11
+uint32_t _patch_ble_ke_time_cmp(void *pRet, uint32_t newer, uint32_t older); // :170:10
+bool ble_ke_time_cmp(uint32_t newer, uint32_t older); // :180:24
+uint32_t _patch_ble_ke_time_past(void *pRet, uint32_t time); // :203:10
+bool ble_ke_time_past(uint32_t time); // :213:24
+uint32_t _patch_ble_ke_timer_hw_set(void *pRet, struct ke_timer *timer); // :234:10
+void ble_ke_timer_hw_set(struct ke_timer *timer); // :297:7
+uint32_t _patch_ble_cmp_abs_time(void *pRet, const struct co_list_hdr *timerA, const struct co_list_hdr *timerB); // :375:10
+bool ble_cmp_abs_time(const struct co_list_hdr *timerA, const struct co_list_hdr *timerB); // :387:24
+uint32_t _patch_ble_cmp_timer_id(void *pRet, const struct co_list_hdr *timer, uint32_t timer_task); // :414:10
+bool ble_cmp_timer_id(const struct co_list_hdr *timer, uint32_t timer_task); // :430:24
+uint32_t _patch_ble_ke_timer_schedule(void *pRet); // :460:10
+void ble_ke_timer_schedule(void); // :505:7
+uint32_t _patch_ble_ke_timer_init(void *pRet); // :560:10
+void ble_ke_timer_init(void); // :568:7
+uint32_t _patch_ble_ke_timer_set(void *pRet, const ke_msg_id_t timer_id, const ke_task_id_t task_id, uint32_t delay); // :580:10
+void ble_ke_timer_set(const ke_msg_id_t timer_id, const ke_task_id_t task_id, uint32_t delay); // :654:7
+uint32_t _patch_ble_ke_timer_clear(void *pRet, const ke_msg_id_t timer_id, const ke_task_id_t task_id); // :731:10
+void ble_ke_timer_clear(const ke_msg_id_t timer_id, const ke_task_id_t task_id); // :776:7
+uint32_t _patch_ble_ke_timer_active(void *pRet, const ke_msg_id_t timer_id, const ke_task_id_t task_id); // :824:10
+bool ble_ke_timer_active(const ke_msg_id_t timer_id, const ke_task_id_t task_id); // :857:24
+void ble_ke_timer_adjust_all(uint32_t delay); // :896:6
+uint32_t _patch_ble_ke_timer_target_get(void *pRet); // :912:10
+uint32_t ble_ke_timer_target_get(void); // :931:11
+
+/* ======== components/network/ble/blecontroller/modules/rf/src/rf_bouffalo.c ======== */
+
+static int8_t g_txpower_dbm; // :27:15
+static int8_t g_txpower_offset; // :28:15
+
+void ble_rf_set_pwr_offset(int8_t offset); // :30:6
+static void rf_txpwr_max_set(int8_t txpwr_dbm); // :41:13
+void ble_controller_set_tx_pwr(int ble_tx_power); // :60:6
+static void rf_reset(void); // :79:13
+static void rf_force_agc_enable(bool en); // :135:13
+static bool rf_txpwr_dec(uint8_t dec); // :142:12
+static bool rf_txpwr_inc(uint8_t inc); // :154:12
+static uint8_t rf_txpwr_dbm_get(uint8_t txpwr_idx, uint8_t modulation); // :173:16
+static int8_t rf_rssi_convert(uint8_t rssi_reg); // :184:15
+static uint32_t rf_reg_rd(uint16_t addr); // :195:17
+static void rf_reg_wr(uint16_t addr, uint32_t value); // :206:13
+static void rf_sleep(void); // :215:13
+void ble_rf_init(struct rwip_rf_api *api); // :229:6
+
+/* ======== components/network/ble/blecontroller/modules/rwip/api/rwip.h ======== */
+
+typedef struct {
+    uint8_t msg_type;
+    void *params;
+} rw_task_msg_t; // :48:2
+
+enum rw_task_msg_type {
+    HOST_TO_FW_MSG = 1,
+    FW_TO_FW_MSG = 2,
+}; // :50:6
+
+enum prevent_sleep {
+    RW_WAKE_UP_ONGOING = 1,
+    RW_TL_TX_ONGOING = 2,
+    RW_TL_RX_ONGOING = 4,
+    RW_AHI_TIMEOUT = 8,
+    RW_CRYPT_ONGOING = 16,
+    RW_DELETE_ELT_ONGOING = 32,
+    RW_CSB_NOT_LPO_ALLOWED = 64,
+    RW_MWS_WLAN_EVENT_GENERATOR_ACTIVE = 128,
+}; // :65:6
+
+enum rwip_eif_types {
+    RWIP_EIF_HCIC = 0,
+    RWIP_EIF_HCIH = 1,
+    RWIP_EIF_AHI = 2,
+}; // :91:6
+
+struct rwip_rf_api {
+    void (*reset)(void);
+    void (*force_agc_enable)(bool);
+    bool (*txpwr_dec)(uint8_t);
+    bool (*txpwr_inc)(uint8_t);
+    void (*txpwr_max_set)(int8_t);
+    uint8_t (*txpwr_dbm_get)(uint8_t, uint8_t);
+    uint8_t (*txpwr_cs_get)(int8_t);
+    int8_t (*rssi_convert)(uint8_t);
+    uint32_t (*reg_rd)(uint16_t);
+    void (*reg_wr)(uint16_t, uint32_t);
+    void (*sleep)(void);
+    uint8_t txpwr_max;
+    int8_t rssi_high_thr;
+    int8_t rssi_low_thr;
+    int8_t rssi_interf_thr;
+    uint8_t wakeup_delay;
+}; // :129:8
+
+struct rwip_prio {
+    uint8_t value;
+    uint8_t increment;
+}; // :166:8
+
+typedef void (*rwip_eif_callback)(void *, uint8_t); // :190:16
+
+struct rwip_eif_api {
+    void (*read)(uint8_t *, uint32_t, rwip_eif_callback, void *);
+    void (*write)(const uint8_t *, uint32_t, rwip_eif_callback, void *);
+    void (*flow_on)(void);
+    bool (*flow_off)(void);
+}; // :195:8
+
+struct rwip_rf_api rwip_rf; // :244:27
+const struct rwip_prio rwip_priority[7]; // :247:31
+const uint8_t rwip_coex_cfg[5]; // :249:22
+
+/* ======== components/network/ble/blecontroller/modules/rwip/api/rwip_config.h ======== */
+
+enum KE_EVENT_TYPE {
+    KE_EVENT_ECC_MULTIPLICATION = 0,
+    KE_EVENT_BLE_CRYPT = 1,
+    KE_EVENT_KE_MESSAGE = 2,
+    KE_EVENT_KE_TIMER = 3,
+    KE_EVENT_H4TL_TX = 4,
+    KE_EVENT_H4TL_CMD_HDR_RX = 5,
+    KE_EVENT_H4TL_CMD_PLD_RX = 6,
+    KE_EVENT_BT_PSCAN_PROC = 7,
+    KE_EVENT_BLE_EVT_DEFER = 8,
+    KE_EVENT_BLE_EVT_DELETE = 9,
+    KE_EVENT_MAX = 10,
+}; // :625:6
+
+enum KE_TASK_TYPE {
+    TASK_LLM = 0,
+    TASK_LLC = 1,
+    TASK_LLD = 2,
+    TASK_DBG = 3,
+    TASK_HCI_ONCHIP = 4,
+    TASK_MAX = 5,
+    TASK_NONE = 255,
+}; // :686:6
+
+enum rwip_coex_config_idx {
+    RWIP_COEX_CON_IDX = 0,
+    RWIP_COEX_CON_DATA_IDX = 1,
+    RWIP_COEX_ADV_IDX = 2,
+    RWIP_COEX_SCAN_IDX = 3,
+    RWIP_COEX_INIT_IDX = 4,
+    RWIP_COEX_CFG_MAX = 5,
+}; // :882:6
+
+enum rwip_prio_idx {
+    RWIP_PRIO_SCAN_IDX = 0,
+    RWIP_PRIO_INIT_IDX = 1,
+    RWIP_PRIO_LE_ESTAB_IDX = 2,
+    RWIP_PRIO_LE_CON_IDLE_IDX = 3,
+    RWIP_PRIO_LE_CON_ACT_IDX = 4,
+    RWIP_PRIO_ADV_IDX = 5,
+    RWIP_PRIO_ADV_HDC_IDX = 6,
+    RWIP_PRIO_IDX_MAX = 7,
+}; // :909:6
+
+enum rwip_prio_dft {
+    RWIP_PRIO_SCAN_DFT = 5,
+    RWIP_PRIO_INIT_DFT = 5,
+    RWIP_PRIO_LE_ESTAB_DFT = 20,
+    RWIP_PRIO_LE_CON_IDLE_DFT = 10,
+    RWIP_PRIO_LE_CON_ACT_DFT = 15,
+    RWIP_PRIO_ADV_DFT = 5,
+    RWIP_PRIO_ADV_HDC_DFT = 10,
+    RWIP_PRIO_MAX = 31,
+}; // :972:6
+
+enum rwip_incr_dft {
+    RWIP_INCR_SCAN_DFT = 1,
+    RWIP_INCR_INIT_DFT = 1,
+    RWIP_INCR_LE_ESTAB_DFT = 1,
+    RWIP_INCR_LE_CON_IDLE_DFT = 1,
+    RWIP_INCR_LE_CON_ACT_DFT = 11,
+    RWIP_INCR_ADV_DFT = 1,
+    RWIP_INCR_ADV_HDC_PRIO_DFT = 1,
+}; // :1037:6
+
+/* ======== components/network/ble/blecontroller/modules/rwip/api/rwip_task.h ======== */
+
+enum TASK_API_ID {
+    TASK_ID_LLM = 0,
+    TASK_ID_LLC = 1,
+    TASK_ID_LLD = 2,
+    TASK_ID_DBG = 3,
+    TASK_ID_LM = 4,
+    TASK_ID_LC = 5,
+    TASK_ID_LB = 6,
+    TASK_ID_LD = 7,
+    TASK_ID_HCI = 8,
+    TASK_ID_DISPLAY = 9,
+    TASK_ID_L2CC = 10,
+    TASK_ID_GATTM = 11,
+    TASK_ID_GATTC = 12,
+    TASK_ID_GAPM = 13,
+    TASK_ID_GAPC = 14,
+    TASK_ID_APP = 15,
+    TASK_ID_AHI = 16,
+    TASK_ID_DISS = 20,
+    TASK_ID_DISC = 21,
+    TASK_ID_PROXM = 22,
+    TASK_ID_PROXR = 23,
+    TASK_ID_FINDL = 24,
+    TASK_ID_FINDT = 25,
+    TASK_ID_HTPC = 26,
+    TASK_ID_HTPT = 27,
+    TASK_ID_BLPS = 28,
+    TASK_ID_BLPC = 29,
+    TASK_ID_HRPS = 30,
+    TASK_ID_HRPC = 31,
+    TASK_ID_TIPS = 32,
+    TASK_ID_TIPC = 33,
+    TASK_ID_SCPPS = 34,
+    TASK_ID_SCPPC = 35,
+    TASK_ID_BASS = 36,
+    TASK_ID_BASC = 37,
+    TASK_ID_HOGPD = 38,
+    TASK_ID_HOGPBH = 39,
+    TASK_ID_HOGPRH = 40,
+    TASK_ID_GLPS = 41,
+    TASK_ID_GLPC = 42,
+    TASK_ID_RSCPS = 43,
+    TASK_ID_RSCPC = 44,
+    TASK_ID_CSCPS = 45,
+    TASK_ID_CSCPC = 46,
+    TASK_ID_ANPS = 47,
+    TASK_ID_ANPC = 48,
+    TASK_ID_PASPS = 49,
+    TASK_ID_PASPC = 50,
+    TASK_ID_CPPS = 51,
+    TASK_ID_CPPC = 52,
+    TASK_ID_LANS = 53,
+    TASK_ID_LANC = 54,
+    TASK_ID_IPSS = 55,
+    TASK_ID_IPSC = 56,
+    TASK_ID_ENVS = 57,
+    TASK_ID_ENVC = 58,
+    TASK_ID_WSCS = 59,
+    TASK_ID_WSCC = 60,
+    TASK_ID_UDSS = 61,
+    TASK_ID_UDSC = 62,
+    TASK_ID_BCSS = 63,
+    TASK_ID_BCSC = 64,
+    TASK_ID_WPTS = 65,
+    TASK_ID_WPTC = 66,
+    TASK_ID_PLXS = 67,
+    TASK_ID_PLXC = 68,
+    TASK_ID_AM0 = 240,
+    TASK_ID_AM0_HAS = 241,
+    TASK_ID_INVALID = 255,
+}; // :50:6
+
+/* ======== components/network/ble/blecontroller/modules/rwip/src/rwip.c ======== */
+
+typedef struct {
+    uint32_t time;
+    uint32_t next_tick;
+} rwip_time_t; // :142:3
+
+const struct rwip_prio rwip_priority[7]; // :190:24
+const uint8_t rwip_coex_cfg[5]; // :225:15
+
+struct rwip_env_tag {
+    uint32_t lp_cycle_wakeup_delay;
+    uint32_t sleep_acc_error;
+    uint16_t sleep_algo_dur;
+    uint16_t prevent_sleep;
+    bool sleep_enable;
+    bool ext_wakeup_enable;
+}; // :258:8
+
+static struct rwip_env_tag rwip_env; // :280:28
+struct rwip_rf_api rwip_rf; // :283:20
+uint8_t *rwip_heap_em; // :303:10
+uint32_t rwip_heap_ram[707]; // :304:10
+int32_t sw_wakeup_cnt; // :1071:9
+int32_t sleep_dur_cnt; // :1078:9
+int32_t sleep_stat_cnt; // :1079:9
+int32_t sleep_cnt; // :1080:9
+
+bool rwip_ext_wakeup_enable(void); // :1483:5
+uint32_t rwip_sleep_lpcycles_2_us(uint32_t lpcycles); // :1506:10
+uint32_t rwip_us_2_lpcycles(uint32_t us); // :1558:10
+void rwip_wlcoex_set(bool state); // :1615:6
+
+/* ======== components/network/ble/blecontroller/plf/refip/src/arch/arch.h ======== */
+
+void (*ble_post_task_ptr)(void); // :246:15
+uint32_t (*_rom_patch_hook)(void *, ...); // :252:19
+
+/* ======== components/network/ble/blecontroller/plf/refip/src/arch/main/arch_main.c ======== */
+
+QueueHandle_t xRwmainQueue; // :104:15
+uint32_t rw_main_task_hdl; // :105:10
+const struct rwip_eif_api uart_api; // :127:27
+uint32_t error; // :147:10
+uint32_t critical_sec_cnt; // :149:10
+void *(*ble_memcpy_ptr)(void *, const void *, unsigned int); // :153:10
+void *(*ble_memset_ptr)(void *, int, unsigned int); // :154:10
+int (*ble_memcmp_ptr)(const void *, const void *, unsigned int); // :155:8
+void (*ble_post_task_ptr)(void); // :156:9
+uint32_t (*_rom_patch_hook)(void *, ...); // :157:13
+
+void BLE_ROM_hook_init(void); // :168:6
+uint32_t BLE_ROM_patch(void *pRet); // :244:10
+uint16_t get_stack_usage(void); // :582:10
+void platform_reset(uint32_t error); // :591:6
+void blecontroller_main(void *pvParameters); // :627:6
+bool rw_main_task_post(void *msg, uint32_t timeout); // :655:5
+void rw_main_task_post_from_isr(void); // :666:6
+void rw_main_task_post_from_fw(void); // :682:6
+void bdaddr_init(void); // :706:6
+
+volatile uint8_t Is_ext_scan_enable; // :769:18
+volatile uint8_t Is_ready_to_rec_auxpacket; // :770:18
+volatile uint32_t Rec_sync_basecnt; // :772:19
+volatile uint32_t Rec_sync_fnt; // :773:19
+
+void ble_controller_init(uint8_t task_priority); // :782:6
+void ble_controller_deinit(void); // :866:6
+const struct rwip_eif_api *rwip_eif_get(uint8_t type); // :890:28
+
+/* ======== components/network/ble/blecontroller/plf/refip/src/driver/sec_eng/sec_eng.c ======== */
+
+struct pka0_pld_cfg {
+    union {
+        struct {
+            uint32_t size:12;
+            uint32_t d_reg_index:8;
+            uint32_t d_reg_type:4;
+            uint32_t op:7;
+            uint32_t last_op:1;
+        } BF;
+        uint32_t WORD;
+    } value;
+}; // :48:8
+
+struct pka0_common_op_first_cfg {
+    union {
+        struct {
+            uint32_t s0_reg_idx:8;
+            uint32_t s0_reg_type:4;
+            uint32_t d_reg_idx:8;
+            uint32_t d_reg_type:4;
+            uint32_t op:7;
+            uint32_t last_op:1;
+        } BF;
+        uint32_t WORD;
+    } value;
+}; // :61:8
+
+struct pka0_common_op_snd_cfg_S1_only {
+    union {
+        struct {
+            uint32_t reserved_0_11:12;
+            uint32_t s1_reg_idx:8;
+            uint32_t s1_reg_type:4;
+            uint32_t reserved_24_31:8;
+        } BF;
+        uint32_t WORD;
+    } value;
+}; // :75:8
+
+struct pka0_common_op_snd_cfg_S2_only {
+    union {
+        struct {
+            uint32_t s2_reg_idx:8;
+            uint32_t s2_reg_type:4;
+            uint32_t reserved_12_31:20;
+        } BF;
+        uint32_t WORD;
+    } value;
+}; // :87:8
+
+struct pka0_common_op_snd_cfg_S1_S2 {
+    union {
+        struct {
+            uint32_t s2_reg_idx:8;
+            uint32_t s2_reg_type:4;
+            uint32_t s1_reg_idx:8;
+            uint32_t s1_reg_type:4;
+            uint32_t reserved_24_31:8;
+        } BF;
+        uint32_t WORD;
+    } value;
+}; // :98:8
+
+struct pka0_bit_shift_op_cfg {
+    union {
+        struct {
+            uint32_t bit_shift:15;
+            uint32_t reserved_24_31:17;
+        } BF;
+        uint32_t WORD;
+    } value;
+}; // :111:8
+
+void sec_eng_pka0_reset(void); // :124:6
+void sec_eng_pka0_clear_int(void); // :137:6
+void sec_eng_pka0_pld(uint16_t size, const uint32_t *data, uint8_t reg_index, uint8_t reg_type, uint8_t op, bool last_op); // :219:6
+static void pka0_write_common_op_first_cfg(uint8_t s0_reg_index, uint8_t s0_reg_type, uint8_t d_reg_index, uint8_t d_reg_type, uint8_t op, bool last_op); // :228:13
+static void pka0_write_common_op_snd_cfg_S1(uint8_t s1_reg_index, uint8_t s1_reg_type); // :249:13
+static void pka0_write_common_op_snd_cfg_S1_S2(uint8_t s1_reg_index, uint8_t s1_reg_type, uint8_t s2_reg_index, uint8_t s2_reg_type); // :275:13
+void sec_eng_pka0_wait_4_isr(void); // :291:6
+void sec_eng_pka0_read_data(uint8_t reg_ype, uint8_t reg_idx, uint32_t *result, uint8_t ret_size); // :342:6
+void sec_eng_pka0_clir(uint8_t last_op, uint8_t d_reg_type, uint8_t d_reg_idx, uint8_t size); // :363:6
+void sec_eng_pka0_movdat(uint8_t last_op, uint8_t d_reg_type, uint8_t d_reg_idx, uint8_t s0_reg_type, uint8_t s0_reg_idx); // :376:6
+void sec_eng_pka0_msub(uint8_t last_op, uint8_t d_reg_type, uint8_t d_reg_idx, uint8_t s0_reg_type, uint8_t s0_reg_idx, uint8_t s1_reg_type, uint8_t s1_reg_idx, uint8_t s2_reg_type, uint8_t s2_reg_idx); // :393:6
+void sec_eng_pka0_mrem(uint8_t last_op, uint8_t d_reg_type, uint8_t d_reg_idx, uint8_t s0_reg_type, uint8_t s0_reg_idx, uint8_t s2_reg_type, uint8_t s2_reg_idx); // :400:6
+void sec_eng_pka0_mmul(uint8_t last_op, uint8_t d_reg_type, uint8_t d_reg_idx, uint8_t s0_reg_type, uint8_t s0_reg_idx, uint8_t s1_reg_type, uint8_t s1_reg_idx, uint8_t s2_reg_type, uint8_t s2_reg_idx); // :407:6
+void sec_eng_pka0_mexp(uint8_t last_op, uint8_t d_reg_type, uint8_t d_reg_idx, uint8_t s0_reg_type, uint8_t s0_reg_idx, uint8_t s1_reg_type, uint8_t s1_reg_idx, uint8_t s2_reg_type, uint8_t s2_reg_idx); // :414:6
+void sec_eng_pka0_lcmp(uint8_t *cout, uint8_t s0_reg_type, uint8_t s0_reg_idx, uint8_t s1_reg_type, uint8_t s1_reg_idx); // :422:6
+void sec_eng_pka0_ladd(uint8_t last_op, uint8_t d_reg_type, uint8_t d_reg_idx, uint8_t s0_reg_type, uint8_t s0_reg_idx, uint8_t s1_reg_type, uint8_t s1_reg_idx); // :438:6
+void sec_eng_pka0_lsub(uint8_t last_op, uint8_t d_reg_type, uint8_t d_reg_idx, uint8_t s0_reg_type, uint8_t s0_reg_idx, uint8_t s1_reg_type, uint8_t s1_reg_idx); // :446:6
+void sec_eng_pka0_lmul(uint8_t last_op, uint8_t d_reg_type, uint8_t d_reg_idx, uint8_t s0_reg_type, uint8_t s0_reg_idx, uint8_t s1_reg_type, uint8_t s1_reg_idx); // :453:6
+void sec_eng_pka0_lmul2n(uint8_t last_op, uint8_t d_reg_type, uint8_t d_reg_idx, uint8_t s0_reg_type, uint8_t s0_reg_idx, uint16_t bit_shift); // :460:6
+void sec_eng_pka0_ldiv2n(uint8_t last_op, uint8_t d_reg_type, uint8_t d_reg_idx, uint8_t s0_reg_type, uint8_t s0_reg_idx, uint16_t bit_shift); // :474:6
+
+/* ======== components/network/ble/blecontroller/plf/refip/src/driver/uart/uart.c ======== */
+
+struct uart_txchannel {
+    void (*callback)(void *, uint8_t);
+    void *dummy;
+    uint32_t remain_size;
+    const uint8_t *remain_data;
+}; // :48:8
+
+struct uart_rxchannel {
+    void (*callback)(void *, uint8_t);
+    void *dummy;
+    uint32_t remain_size;
+    uint8_t *remain_data;
+}; // :58:8
+
+struct uart_env_tag {
+    struct uart_txchannel tx;
+    struct uart_rxchannel rx;
+}; // :69:8
+
+static struct uart_env_tag uart_env; // :83:28
+static uint32_t uart_addr; // :85:17
+static uint8_t uart_id; // :86:16
+
+void uart_flow_on(void); // :415:6
+bool uart_flow_off(void); // :421:5
+void uart_finish_transfers(void); // :448:6
+static void write_data(const uint8_t *bufptr, uint32_t size); // :456:13
+static uint8_t read_data(void); // :470:16
+static uint8_t read_fifo_data(uint8_t num); // :488:16
+void uart_read(uint8_t *bufptr, uint32_t size, void (*callback)(void *, uint8_t), void *dummy); // :511:6
+void uart_write(const uint8_t *bufptr, uint32_t size, void (*callback)(void *, uint8_t), void *dummy); // :554:6
+void uart_read_blocking(uint8_t *bufptr, uint32_t size); // :599:6
+void uart_write_blocking(const uint8_t *bufptr, uint32_t size); // :612:6
+void uart_rx_isr(void); // :645:6
+void uart_tx_isr(void); // :697:6
+void uart_rx_fifo_isr(void); // :725:6
+void uart_tx_fifo_isr(void); // :824:6
+void uart_isr(void); // :865:6


### PR DESCRIPTION
This PR adds (pseudo-)headers generated from DWARF info. Declarations are grouped by names of source files (in which they were defined). Comments at the end of line contain source locations (in form `:line:column`).